### PR TITLE
Remove creates guard for extracting tarball which prevents upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is used to list changes made in each version of the docker cookbook.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Remove creates guard for extracting tarball which prevents upgrades
+
 ## 7.2.1 (2020-11-03)
 
 - Fix issue with `default-ip-addr` in systemd

--- a/libraries/docker_installation_tarball.rb
+++ b/libraries/docker_installation_tarball.rb
@@ -77,7 +77,6 @@ module DockerCookbook
       execute 'extract tarball' do
         action :nothing
         command "tar -xzf #{docker_tarball} --strip-components=1 -C #{docker_bin_prefix}"
-        creates docker_bin
       end
 
       group 'docker' do


### PR DESCRIPTION
### Description

This guard prevents you from installing a newer or different version of the
tarball from one you had initially installed. Since the default action is set to
nothing and gets triggered from downloading a new tarball, this shouldn't be a
problem.

Signed-off-by: Lance Albertson <lance@osuosl.org>

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
