### PR TITLE
detect arch for .debs

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -29,7 +29,7 @@ module DockerCookbook
           apt_repository 'Docker' do
             components Array(new_resource.repo_channel)
             uri "https://download.docker.com/linux/#{node['platform']}"
-            arch 'amd64'
+            arch node['packages']['dpkg']['arch'] # Get the arch from a package that is always installed.
             keyserver 'keyserver.ubuntu.com'
             key "https://download.docker.com/linux/#{node['platform']}/gpg"
             action :add


### PR DESCRIPTION
### Description

docker is available for debian/ubuntu on `amd6`, `arm64`, `armhf`, `ppc64el`, and `s390x`.

This allows this cookbook to work on the current list of archs and any new ones.

### Issues Resolved

I'm filing a PR instead of an issue.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>