### PR TITLE
#1129 - fix issue with default-ip-addr in systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is used to list changes made in each version of the docker cookbook.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fix issue with `default-ip-addr` in systemd
+
 ## 7.2.0 (2020-10-26)
 
 - Add `cpus` options to `docker_container`

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -217,7 +217,7 @@ module DockerCookbook
         opts << "--fixed-cidr-v6=#{fixed_cidr_v6}" if fixed_cidr_v6
         opts << "--group=#{group}" if group
         opts << "--data-root=#{data_root}" if data_root
-        opts << "--default-address-pool=#{default_ip_address_pool}" unless default_ip_address_pool.nil?
+        opts << "--default-address-pool #{default_ip_address_pool}" unless default_ip_address_pool.nil?
         host.each { |h| opts << "--host #{h}" } if host
         opts << "--icc=#{icc}" unless icc.nil?
         insecure_registry.each { |i| opts << "--insecure-registry=#{i}" } if insecure_registry

--- a/spec/docker_test/service_spec.rb
+++ b/spec/docker_test/service_spec.rb
@@ -32,7 +32,7 @@ ExecStartPre=/sbin/sysctl -w net.ipv6.conf.all.forwarding=1
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd  --bip=10.10.10.0/24 --group=docker --default-address-pool=base=10.10.10.0/16,size=24 --pidfile=/var/run/docker.pid --storage-driver=overlay2 --containerd=/run/containerd/containerd.sock
+ExecStart=/usr/bin/dockerd  --bip=10.10.10.0/24 --group=docker --default-address-pool base=10.10.10.0/16,size=24 --pidfile=/var/run/docker.pid --storage-driver=overlay2 --containerd=/run/containerd/containerd.sock
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0
 RestartSec=2
@@ -109,7 +109,7 @@ ExecStartPre=/sbin/sysctl -w net.ipv6.conf.all.forwarding=1
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd  --bip=10.10.10.0/24 --group=docker --default-address-pool=base=10.10.10.0/16,size=24 --pidfile=/var/run/docker.pid --storage-driver=overlay2
+ExecStart=/usr/bin/dockerd  --bip=10.10.10.0/24 --group=docker --default-address-pool base=10.10.10.0/16,size=24 --pidfile=/var/run/docker.pid --storage-driver=overlay2
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0
 RestartSec=2


### PR DESCRIPTION
systemd typo for default-ip-address

### Description
The change corrects a typo in the systemd 
https://github.com/chef-cookbooks/docker/blob/master/libraries/helpers_service.rb

Line 205 is currently

        opts << "--default-address-pool=#{default_ip_address_pool}" unless default_ip_address_pool.nil?
and needs to be

        opts << "--default-address-pool #{default_ip_address_pool}" unless default_ip_address_pool.nil?

### Issues Resolved
#1129 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>