### PR TITLE
attempt to fix #1142

### DIFF
--- a/libraries/docker_base.rb
+++ b/libraries/docker_base.rb
@@ -128,9 +128,20 @@ module DockerCookbook
     alias_method :tlsverify, :tls_verify
 
     declare_action_class.class_eval do
-      # https://github.com/docker/docker/blob/4fcb9ac40ce33c4d6e08d5669af6be5e076e2574/registry/auth.go#L231
       def parse_registry_host(val)
-        val.sub(%r{https?://}, '').split('/').first
+        # example values for val, can be prefixed with http(s):// :
+        #   image                    (=> Docker Hub)
+        #   organization/image       (=> Docker Hub)
+        #   domain.ext/image         (=> 3rd party registry)
+        #   domain.ext/.../image     (=> 3rd party registry)
+        #
+        first_part = val.sub(%r{https?://}, '').split('/').first
+
+        # looks like a host name of a custom docker registry
+        return first_part if first_part.include?('.')
+
+        # default host
+        'index.docker.io'
       end
     end
   end

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -183,7 +183,7 @@ module DockerCookbook
 
       def credentails
         registry_host = parse_registry_host(new_resource.repo)
-        node.run_state['docker_auth'] && node.run_state['docker_auth'][registry_host] || (node.run_state['docker_auth'] ||= {})['index.docker.io']
+        node.run_state['docker_auth'] && node.run_state['docker_auth'][registry_host] || {}
       end
     end
   end


### PR DESCRIPTION
# Description

Dockers image naming scheme is problematic, it can be "user/image" for public docker hub or something like "hostname.domain/image" for 3rd party registries. In theory even "localhost/image" may be valid but there is AFAIK no way to differentiate between the different use cases. I therefore assume nobody addesses a registry without a FQDN.


## Issues Resolved

#1142

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
