### PR TITLE
GH-1144, update the registry_mirror option to allow multiple mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is used to list changes made in each version of the docker cookbook.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Updates the `registry_mirror` option of `docker_service` to be either a string or array. This way multiple mirrors can be configured
+
 ## 7.2.2 (2020-11-05)
 
 - Remove creates guard for extracting tarball which prevents upgrades

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ The `docker_service` resource property list mostly corresponds to the options fo
 - `no_proxy` - ENV variable set before for Docker daemon starts
 - `package_name` - Set the package name. Defaults to `docker-ce`
 - `pidfile` - Path to use for daemon PID file
-- `registry_mirror` - Preferred Docker registry mirror
+- `registry_mirror` - A string or array to set the preferred Docker registry mirror(s)
 - `selinux_enabled` - Enable selinux support
 - `source` - URL to the pre-compiled Docker binary used for installation. Defaults to a calculated URL based on kernel version, Docker version, and platform arch. By default, this will try to get to "<http://get.docker.io/builds/>".
 - `storage_driver` - Storage driver to use

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -56,7 +56,7 @@ module DockerCookbook
     property :mount_flags, String
     property :mtu, String
     property :pidfile, String, default: lazy { "/var/run/#{docker_name}.pid" }
-    property :registry_mirror, String
+    property :registry_mirror, [String, Array], coerce: proc { |v| v.nil? ? nil : Array(v) }
     property :storage_driver, [String, Array], coerce: proc { |v| v.nil? ? nil : Array(v) }
     property :selinux_enabled, [true, false]
     property :storage_opts, Array

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -232,7 +232,7 @@ module DockerCookbook
         log_opts.each { |log_opt| opts << "--log-opt '#{log_opt}'" } if log_opts
         opts << "--mtu=#{mtu}" if mtu
         opts << "--pidfile=#{pidfile}" if pidfile
-        opts << "--registry-mirror=#{registry_mirror}" if registry_mirror
+        registry_mirror.each { |mirror| opts << "--registry-mirror=#{mirror}" } if registry_mirror
         storage_driver.each { |s| opts << "--storage-driver=#{s}" } if storage_driver
         opts << "--selinux-enabled=#{selinux_enabled}" unless selinux_enabled.nil?
         storage_opts.each { |storage_opt| opts << "--storage-opt=#{storage_opt}" } if storage_opts

--- a/spec/docker_test/service_spec.rb
+++ b/spec/docker_test/service_spec.rb
@@ -76,6 +76,18 @@ EOH
       expect(content.gsub(/[\r\n]+/m, "\n")).to match(expected.gsub(/[\r\n]+/m, "\n"))
     }
   end
+  it 'allows a single registry mirror to be configured' do
+    expect(chef_run).to render_file('/etc/systemd/system/docker-one-mirror.service').with_content { |content|
+      expected_start_command = 'ExecStart=/usr/bin/dockerd  --group=docker --data-root=/var/lib/docker-one --host unix:///var/run/docker-one.sock --pidfile=/var/run/docker-one-mirror.pid --registry-mirror=https://mirror.gcr.io --containerd=/run/containerd/containerd.sock'
+      expect(content).to include(expected_start_command)
+    }
+  end
+  it 'allows multiple registry mirrors to be configured' do
+    expect(chef_run).to render_file('/etc/systemd/system/docker-two-mirrors.service').with_content { |content|
+      expected_start_command = 'ExecStart=/usr/bin/dockerd  --group=docker --data-root=/var/lib/docker-two --host unix:///var/run/docker-two.sock --pidfile=/var/run/docker-two-mirrors.pid --registry-mirror=https://mirror.gcr.io --registry-mirror=https://another.mirror.io --containerd=/run/containerd/containerd.sock'
+      expect(content).to include(expected_start_command)
+    }
+  end
   it do
     expect(chef_run).to create_template('/etc/systemd/system/containerd.service')
   end

--- a/test/cookbooks/docker_test/recipes/service.rb
+++ b/test/cookbooks/docker_test/recipes/service.rb
@@ -5,3 +5,19 @@ docker_service 'default' do
   service_manager 'systemd'
   action [:create, :start]
 end
+
+docker_service 'one-mirror' do
+  graph '/var/lib/docker-one'
+  host 'unix:///var/run/docker-one.sock'
+  registry_mirror 'https://mirror.gcr.io'
+  service_manager 'systemd'
+  action [:create, :start]
+end
+
+docker_service 'two-mirrors' do
+  graph '/var/lib/docker-two'
+  host 'unix:///var/run/docker-two.sock'
+  registry_mirror ['https://mirror.gcr.io', 'https://another.mirror.io']
+  service_manager 'systemd'
+  action [:create, :start]
+end


### PR DESCRIPTION
# Description

Updates the `registry_mirror` option of `docker_service` to users can provide either a single mirror or a list, solving #1144 

## Issues Resolved

Solves #1144 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
