### PR TITLE
Add `local` value to `log_driver` resource property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Support `local`  option for the `log_driver` properties of `docker_service` and `docker_container` resources
+
 ## 7.3.0 - *2020-12-02*
 
 - Updates the `registry_mirror` option of `docker_service` to be either a string or array. This way multiple mirrors can be configured

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -35,7 +35,7 @@ module DockerCookbook
     property :kernel_memory, [String, Integer], coerce: proc { |v| coerce_to_bytes(v) }, default: 0
     property :labels, [String, Array, Hash], default: {}, coerce: proc { |v| coerce_labels(v) }
     property :links, UnorderedArrayType, coerce: proc { |v| coerce_links(v) }
-    property :log_driver, %w( json-file syslog journald gelf fluentd awslogs splunk etwlogs gcplogs none ), default: 'json-file', desired_state: false
+    property :log_driver, %w( json-file syslog journald gelf fluentd awslogs splunk etwlogs gcplogs none local ), default: 'json-file', desired_state: false
     property :log_opts, [Hash, nil], coerce: proc { |v| coerce_log_opts(v) }, desired_state: false
     property :init, [TrueClass, FalseClass, nil]
     property :ip_address, String

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -51,7 +51,7 @@ module DockerCookbook
     property :default_ip_address_pool, String
     property :log_level, %w(debug info warn error fatal)
     property :labels, [String, Array], coerce: proc { |v| coerce_daemon_labels(v) }, desired_state: false
-    property :log_driver, %w(json-file syslog journald gelf fluentd awslogs splunk none)
+    property :log_driver, %w(json-file syslog journald gelf fluentd awslogs splunk none local)
     property :log_opts, [String, Array], coerce: proc { |v| v.nil? ? nil : Array(v) }
     property :mount_flags, String
     property :mtu, String


### PR DESCRIPTION
# Description

This adds `local` as a supported value for the `log_driver` resource property for both `DockerContainer` and `DockerServiceBase` resources.

cf https://docs.docker.com/config/containers/logging/local/

## Issues Resolved

#1125 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
