### PR TITLE
Allowing for loki docker driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Support for loki-docker driver logging plugin
+
 ## 7.5.0 - *2021-01-04*
 
 - Update to use 20.10 by default

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -35,7 +35,8 @@ module DockerCookbook
     property :kernel_memory, [String, Integer], coerce: proc { |v| coerce_to_bytes(v) }, default: 0
     property :labels, [String, Array, Hash], default: {}, coerce: proc { |v| coerce_labels(v) }
     property :links, UnorderedArrayType, coerce: proc { |v| coerce_links(v) }
-    property :log_driver, %w( json-file syslog journald gelf fluentd awslogs splunk loki-docker etwlogs gcplogs none local ), default: 'json-file', desired_state: false    property :log_opts, [Hash, nil], coerce: proc { |v| coerce_log_opts(v) }, desired_state: false
+    property :log_driver, %w( json-file syslog journald gelf fluentd awslogs splunk loki-docker etwlogs gcplogs none local ), default: 'json-file', desired_state: false
+    property :log_opts, [Hash, nil], coerce: proc { |v| coerce_log_opts(v) }, desired_state: false
     property :init, [TrueClass, FalseClass, nil]
     property :ip_address, String
     property :mac_address, String

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -35,8 +35,7 @@ module DockerCookbook
     property :kernel_memory, [String, Integer], coerce: proc { |v| coerce_to_bytes(v) }, default: 0
     property :labels, [String, Array, Hash], default: {}, coerce: proc { |v| coerce_labels(v) }
     property :links, UnorderedArrayType, coerce: proc { |v| coerce_links(v) }
-    property :log_driver, %w( json-file syslog journald gelf fluentd awslogs splunk etwlogs gcplogs none local ), default: 'json-file', desired_state: false
-    property :log_opts, [Hash, nil], coerce: proc { |v| coerce_log_opts(v) }, desired_state: false
+    property :log_driver, %w( json-file syslog journald gelf fluentd awslogs splunk loki-docker etwlogs gcplogs none local ), default: 'json-file', desired_state: false    property :log_opts, [Hash, nil], coerce: proc { |v| coerce_log_opts(v) }, desired_state: false
     property :init, [TrueClass, FalseClass, nil]
     property :ip_address, String
     property :mac_address, String


### PR DESCRIPTION
# Description

This PR adds in support for the loki-docker driver that can be installed via the docker plugin resource, line can also be adjusted to below to allow for any custom logging docker plugin

`property :log_driver, String, default: 'json-file'. desired_state: false`


## Issues Resolved

#1124 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
