### PR TITLE
Update to use 20.10 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Update to use 20.10 by default
+- Update tarball for 19.03 to 19.03.14
+
 ## 7.4.1 - *2021-01-01*
 
 - Fix the codeowners to use the correct group

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ The `docker_installation_package` resource uses the system package manager to in
 
 ```ruby
 docker_installation_package 'default' do
-  version '19.03.13'
+  version '20.10.1'
   action :create
   package_options %q|--force-yes -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-all'| # if Ubuntu for example
 end

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -59,9 +59,6 @@ suites:
       - recipe[docker_test::installation_script]
 
   - name: installation_package
-    attributes:
-      docker:
-        version: '20.10.1'
     run_list:
       - recipe[docker_test::installation_package]
     excludes:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -61,7 +61,7 @@ suites:
   - name: installation_package
     attributes:
       docker:
-        version: '19.03.13'
+        version: '20.10.1'
     run_list:
       - recipe[docker_test::installation_package]
     excludes:
@@ -81,7 +81,7 @@ suites:
       multiple_converge: 1
     attributes:
       docker:
-        version: '19.03.13'
+        version: '20.10.1'
     run_list:
       - recipe[docker_test::default]
       - recipe[docker_test::image]
@@ -98,7 +98,7 @@ suites:
       multiple_converge: 1
     attributes:
       docker:
-        version: '19.03.13'
+        version: '20.10.1'
     run_list:
       - recipe[docker_test::default]
       - recipe[docker_test::network]
@@ -112,7 +112,7 @@ suites:
       multiple_converge: 1
     attributes:
       docker:
-        version: '19.03.13'
+        version: '20.10.1'
     run_list:
       - recipe[docker_test::default]
       - recipe[docker_test::volume]
@@ -126,7 +126,7 @@ suites:
       multiple_converge: 1
     attributes:
       docker:
-        version: '19.03.13'
+        version: '20.10.1'
     run_list:
       - recipe[docker_test::default]
       - recipe[docker_test::registry]

--- a/libraries/docker_installation_tarball.rb
+++ b/libraries/docker_installation_tarball.rb
@@ -6,7 +6,7 @@ module DockerCookbook
     property :checksum, String, default: lazy { default_checksum }, desired_state: false
     property :source, String, default: lazy { default_source }, desired_state: false
     property :channel, String, default: 'stable', desired_state: false
-    property :version, String, default: '19.03.13', desired_state: false
+    property :version, String, default: '20.10.1', desired_state: false
 
     ##################
     # Property Helpers
@@ -44,14 +44,16 @@ module DockerCookbook
         when '18.03.1' then 'bbfb9c599a4fdb45523496c2ead191056ff43d6be90cf0e348421dd56bc3dcf0'
         when '18.06.3' then 'f7347ef27db9a438b05b8f82cd4c017af5693fe26202d9b3babf750df3e05e0c'
         when '18.09.9' then 'ed83a3d51fef2bbcdb19d091ff0690a233aed4bbb47d2f7860d377196e0143a0'
-        when '19.03.13' then 'd035d468218c26973710b35101b55dcf82c25d43a0a88aaa9f667b1782ec6ea4'
+        when '19.03.14' then '7fbf94a39f0034035c129ca7463234263015e97f7e5747beaf6a8ba9e535e0c3'
+        when '20.10.1' then 'bfcbfa86b7df1c1312293ccf7faf29dd55ec501e5bbdc9cb38eb47ed976e554c'
         end
       when 'Linux'
         case version
         when '18.03.1' then '0e245c42de8a21799ab11179a4fce43b494ce173a8a2d6567ea6825d6c5265aa'
         when '18.06.3' then '346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822'
         when '18.09.9' then '82a362af7689038c51573e0fd0554da8703f0d06f4dfe95dd5bda5acf0ae45fb'
-        when '19.03.13' then 'ddb13aff1fcdcceb710bf71a210169b9c1abfd7420eeaf42cf7975f8fae2fcc8'
+        when '19.03.14' then '9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847'
+        when '20.10.1' then '8790f3b94ee07ca69a9fdbd1310cbffc729af0a07e5bf9f34a79df1e13d2e50e'
         end
       end
     end

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -9,7 +9,7 @@ describe 'docker_test::installation_package' do
 
   context 'testing default action, default properties' do
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '19.03.13')
+      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.1')
     end
   end
 

--- a/test/cookbooks/docker_test/recipes/installation_package.rb
+++ b/test/cookbooks/docker_test/recipes/installation_package.rb
@@ -1,5 +1,15 @@
-docker_installation_package 'default' do
+docker_ver =
   # Include epoch on RHEL to fix idempotency issues
-  version platform_family?('rhel', 'fedora') ? '3:20.10.1' : '20.10.1'
+  if platform_family?('rhel', 'fedora')
+    '3:20.10.1'
+  # Debian 9 does not include 20.10
+  elsif platform?('debian') && node['platform_version'].to_i == 9
+    '19.03.14'
+  else
+    '20.10.1'
+  end
+
+docker_installation_package 'default' do
+  version docker_ver
   action :create
 end

--- a/test/cookbooks/docker_test/recipes/installation_package.rb
+++ b/test/cookbooks/docker_test/recipes/installation_package.rb
@@ -1,5 +1,5 @@
 docker_installation_package 'default' do
   # Include epoch on RHEL to fix idempotency issues
-  version platform_family?('rhel', 'fedora') ? '3:19.03.13' : '19.03.13'
+  version platform_family?('rhel', 'fedora') ? '3:20.10.1' : '20.10.1'
   action :create
 end

--- a/test/cookbooks/docker_test/recipes/installation_tarball.rb
+++ b/test/cookbooks/docker_test/recipes/installation_tarball.rb
@@ -1,3 +1,3 @@
 docker_installation_tarball 'default' do
-  version '19.03.13'
+  version '20.10.1'
 end

--- a/test/integration/installation_package/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_package/inspec/assert_functioning_spec.rb
@@ -1,6 +1,8 @@
-if os[:name] == 'amazon'
+# Debian 9 does not include 20.10
+if os.name == 'debian' && os.release.to_i == 9
   describe command('/usr/bin/docker --version') do
     its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(/19\.03\./) }
   end
 else
   describe command('/usr/bin/docker --version') do

--- a/test/integration/installation_package/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_package/inspec/assert_functioning_spec.rb
@@ -5,6 +5,6 @@ if os[:name] == 'amazon'
 else
   describe command('/usr/bin/docker --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/19\.03\./) }
+    its(:stdout) { should match(/20\.10\./) }
   end
 end

--- a/test/integration/installation_tarball/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_tarball/inspec/assert_functioning_spec.rb
@@ -1,6 +1,6 @@
 describe command '/usr/bin/docker --version' do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/19.03.13/) }
+  its(:stdout) { should match(/20.10.1/) }
 end
 
 describe group 'docker' do

--- a/test/integration/resources/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources/inspec/assert_functioning_spec.rb
@@ -10,7 +10,7 @@ chef_dir = file('/opt/cinc').exist? ? '/opt/cinc' : '/opt/chef'
 # docker_service[default]
 
 describe docker.version do
-  its('Server.Version') { should eq '19.03.13' }
+  its('Server.Version') { should eq '20.10.1' }
 end
 
 describe command('docker info') do


### PR DESCRIPTION
Docker 20.10.x was released in December with the latest version being 20.10.1. This updates everything to start using and testing this release. This should fix test failures with the current branch.

In addition, update tarball for 19.03 to 19.03.14.

Signed-off-by: Lance Albertson <lance@osuosl.org>
