### PR TITLE
fixed reload_signal and cpus bug

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -402,7 +402,7 @@ module DockerCookbook
       name
     end
 
-    load_current_value do|new_resource|
+    load_current_value do |new_resource|
       # Grab the container and assign the container property
       begin
         with_retries { container Docker::Container.get(container_name, {}, connection) }

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -402,13 +402,17 @@ module DockerCookbook
       name
     end
 
-    load_current_value do
+    load_current_value do |new_resource|
       # Grab the container and assign the container property
       begin
         with_retries { container Docker::Container.get(container_name, {}, connection) }
       rescue Docker::Error::NotFoundError
         current_value_does_not_exist!
       end
+
+      # reload_signal is not persisted elsewhere, and will cause container 
+      # to restart if different from the default value
+      public_send("reload_signal", new_resource.reload_signal)
 
       # Go through everything in the container and set corresponding properties:
       # c.info['Config']['ExposedPorts'] -> exposed_ports
@@ -417,7 +421,14 @@ module DockerCookbook
 
         # Image => image
         # Set exposed_ports = ExposedPorts (etc.)
-        property_name = to_snake_case(key)
+        case key
+        when "NanoCpus"
+          property_name = "cpus"
+          value = (value / (10**9))
+        else
+          property_name = to_snake_case(key)
+        end
+
         public_send(property_name, value) if respond_to?(property_name)
       end
 

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -424,7 +424,7 @@ module DockerCookbook
         case key
         when 'NanoCpus'
           property_name = 'cpus'
-          value = (value / (10**9))
+          value = (value / (10**9)).to_i
         else
           property_name = to_snake_case(key)
         end

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -402,7 +402,7 @@ module DockerCookbook
       name
     end
 
-    load_current_value do |new_resource|
+    load_current_value do|new_resource|
       # Grab the container and assign the container property
       begin
         with_retries { container Docker::Container.get(container_name, {}, connection) }
@@ -410,9 +410,9 @@ module DockerCookbook
         current_value_does_not_exist!
       end
 
-      # reload_signal is not persisted elsewhere, and will cause container 
+      # reload_signal is not persisted elsewhere, and will cause container
       # to restart if different from the default value
-      public_send("reload_signal", new_resource.reload_signal)
+      public_send('reload_signal', new_resource.reload_signal)
 
       # Go through everything in the container and set corresponding properties:
       # c.info['Config']['ExposedPorts'] -> exposed_ports
@@ -422,8 +422,8 @@ module DockerCookbook
         # Image => image
         # Set exposed_ports = ExposedPorts (etc.)
         case key
-        when "NanoCpus"
-          property_name = "cpus"
+        when 'NanoCpus'
+          property_name = 'cpus'
           value = (value / (10**9))
         else
           property_name = to_snake_case(key)


### PR DESCRIPTION
# Description

Fixes that `reload_signal` and `cpus` made the container restart on every chef run if diffrent from the default value.

## Issues Resolved

See comments in PR #1090