### PR TITLE
fixed reload_signal and cpus bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fixed `reload_signal` and `cpus` bug for `docker_container` in #1090 [@urlund](https://github.com/urlund)
+
 ## 7.6.0 - *2021-01-06*
 
 - Support for loki-docker driver logging plugin

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -428,7 +428,7 @@ module DockerCookbook
         else
           property_name = to_snake_case(key)
         end
-        
+
         public_send(property_name, value) if respond_to?(property_name)
       end
 


### PR DESCRIPTION
# Description

Fixes that `reload_signal` and `cpus` made the container restart on every chef run if diffrent from the default value.

## Issues Resolved

See comments in PR #1090
