### PR TITLE
Add `buildargs` propety to the `docker_image` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add `buildargs` property to `docker_image` resource
+
 ## 7.6.1 - *2021-01-11*
 
 - Fixed `reload_signal` and `cpus` bug for `docker_container` in #1090 [@urlund](https://github.com/urlund)

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ public registry vs a private one.
 - `tls_ca_cert` - Trust certs signed only by this CA. Defaults to `ENV['DOCKER_CERT_PATH']` if set.
 - `tls_client_cert` - Path to TLS certificate file for docker cli. Defaults to `ENV['DOCKER_CERT_PATH']` if set
 - `tls_client_key` - Path to TLS key file for docker cli. Defaults to `ENV['DOCKER_CERT_PATH']` if set.
-- `buildargs` - A string, hash, or array containing build arguments.
+- `buildargs` - A String or Hash containing build arguments.
 
 ### Examples
 
@@ -583,10 +583,6 @@ Hash:
 `buildargs "IMAGE_NAME": "alpine", "IMAGE_TAG": "latest"`
 
 `buildargs "IMAGE_NAME" => "alpine", "IMAGE_TAG" => "latest"`
-
-Array:
-
-`buildargs ["IMAGE_NAME:alpine", "IMAGE_TAG:latest"]`
 
 ```ruby
 docker_image 'image_1' do

--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ public registry vs a private one.
 - `tls_ca_cert` - Trust certs signed only by this CA. Defaults to `ENV['DOCKER_CERT_PATH']` if set.
 - `tls_client_cert` - Path to TLS certificate file for docker cli. Defaults to `ENV['DOCKER_CERT_PATH']` if set
 - `tls_client_key` - Path to TLS key file for docker cli. Defaults to `ENV['DOCKER_CERT_PATH']` if set.
+- `buildargs` - A string, hash, or array containing build arguments.
 
 ### Examples
 
@@ -551,7 +552,7 @@ docker_image 'image_2' do
 end
 ```
 
-- build from a tarball NOTE: this is not an "export" tarball generated from an an image save. The contents should be a Dockerfile, and anything it references to COPY or ADD
+- build from a tarball NOTE: this is not an "export" tarball generated from an image save. The contents should be a Dockerfile, and anything it references to COPY or ADD
 
 ```ruby
 docker_image 'image_3' do
@@ -567,6 +568,43 @@ docker_image 'hello-again' do
   source '/tmp/hello-world.tar'
   action :import
 end
+```
+
+- build from a Dockerfile on every chef-client run with `buildargs`
+
+Acceptable values for `buildargs`:
+
+String:
+
+`buildargs '{"IMAGE_NAME":"alpine","IMAGE_TAG":"latest"}'`
+
+Hash:
+
+`buildargs "IMAGE_NAME": "alpine", "IMAGE_TAG": "latest"`
+
+`buildargs "IMAGE_NAME" => "alpine", "IMAGE_TAG" => "latest"`
+
+Array:
+
+`buildargs ["IMAGE_NAME:alpine", "IMAGE_TAG:latest"]`
+
+```ruby
+docker_image 'image_1' do
+  source '/src/myproject/container1/Dockerfile'
+  buildargs '{"IMAGE_NAME":"alpine","IMAGE_TAG":"latest"}'
+  action :build
+end
+```
+
+Where `Dockerfile` contains:
+
+``` bash
+ARG IMAGE_TAG
+ARG IMAGE_NAME
+FROM $IMAGE_NAME:$IMAGE_TAG
+ARG IMAGE_NAME
+ENV image_name=$IMAGE_NAME
+RUN echo $image_name > /image_name
 ```
 
 - push

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -16,7 +16,6 @@ module DockerCookbook
     property :rm, [true, false], default: true
     property :source, String
     property :tag, String, default: 'latest'
-    property :buildargs, [String, Array, Hash], coerce: proc { |v| coerce_buildargs(v) }
     property :buildargs, [String, Hash], coerce: proc { |v| v.is_a?(String) ? v : coerce_buildargs(v) }
 
     alias_method :image, :repo

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -17,6 +17,7 @@ module DockerCookbook
     property :source, String
     property :tag, String, default: 'latest'
     property :buildargs, [String, Array, Hash], coerce: proc { |v| coerce_buildargs(v) }
+    property :buildargs, [String, Hash], coerce: proc { |v| v.is_a?(String) ? v : coerce_buildargs(v) }
 
     alias_method :image, :repo
     alias_method :image_name, :repo
@@ -28,14 +29,7 @@ module DockerCookbook
     ###################
 
     def coerce_buildargs(v)
-      case v
-      when Hash
-        format('{ %s }', v.map { |key, value| format('"%s": "%s"', key, value) }.join(','))
-      when Array
-        format('{ %s }', v.map { |label| format('"%s": "%s"', label.split(':').first, label.split(':').last) }.join(','))
-      else
-        v
-      end
+      "{ #{v.map { |key, value| "\"#{key}\": \"#{value}\"" }.join(', ')} }"
     end
 
     #########

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -29,12 +29,13 @@ module DockerCookbook
 
     def coerce_buildargs(v)
       case v
-      when Hash
-        format('{ %s }', v.map { |key, value| format('"%s": "%s"', key, value) }.join(','))
-      when Array
-        format('{ %s }', v.map { |label| format('"%s": "%s"', label.split(':').first, label.split(':').last) }.join(','))
-      else
+      when Hash, nil
         v
+      else
+        Array(v).each_with_object({}) do |label, h|
+          parts = label.split(':')
+          h[parts[0]] = parts[1..-1].join(':')
+        end
       end
     end
 

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -30,9 +30,9 @@ module DockerCookbook
     def coerce_buildargs(v)
       case v
       when Hash
-        '{ %s }' % v.map { |k, v| '"%s": "%s"' % [k, v] }.join(',')
+        format('{ %s }', v.map { |key, value| format('"%s": "%s"', key, value) }.join(','))
       when Array
-        '{ %s }' % v.map { |label| '"%s": "%s"' % [label.split(':').first, label.split(':').last] }.join(',')
+        format('{ %s }', v.map { |label| format('"%s": "%s"', label.split(':').first, label.split(':').last) }.join(','))
       else
         v
       end

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -30,18 +30,9 @@ module DockerCookbook
     def coerce_buildargs(v)
       case v
       when Hash
-        str = ''
-        v.each do |key, value|
-          str += '"' + key.to_s + '": "' + value.to_s + '",'
-        end
-        '{ ' + str.delete_suffix(',') + ' }'
+        '{ %s }' % v.map { |k, v| '"%s": "%s"' % [k, v] }.join(',')
       when Array
-        str = ''
-        Array(v).each do |label|
-          parts = label.split(':')
-          str += '"' + parts[0].to_s + '": "' + parts[1].to_s + '",'
-        end
-        '{ ' + str.delete_suffix(',') + ' }'
+        '{ %s }' % v.map { |label| '"%s": "%s"' % [label.split(':').first, label.split(':').last] }.join(',')
       else
         v
       end

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -29,13 +29,12 @@ module DockerCookbook
 
     def coerce_buildargs(v)
       case v
-      when Hash, nil
-        v
+      when Hash
+        format('{ %s }', v.map { |key, value| format('"%s": "%s"', key, value) }.join(','))
+      when Array
+        format('{ %s }', v.map { |label| format('"%s": "%s"', label.split(':').first, label.split(':').last) }.join(','))
       else
-        Array(v).each_with_object({}) do |label, h|
-          parts = label.split(':')
-          h[parts[0]] = parts[1..-1].join(':')
-        end
+        v
       end
     end
 

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -16,11 +16,36 @@ module DockerCookbook
     property :rm, [true, false], default: true
     property :source, String
     property :tag, String, default: 'latest'
+    property :buildargs, [String, Array, Hash], coerce: proc { |v| coerce_buildargs(v) }
 
     alias_method :image, :repo
     alias_method :image_name, :repo
     alias_method :no_cache, :nocache
     alias_method :no_prune, :noprune
+
+    ###################
+    # Property helpers
+    ###################
+
+    def coerce_buildargs(v)
+      case v
+      when Hash
+        str = ''
+        v.each do |key, value|
+          str += '"' + key.to_s + '": "' + value.to_s + '",'
+        end
+        '{ ' + str.delete_suffix(',') + ' }'
+      when Array
+        str = ''
+        Array(v).each do |label|
+          parts = label.split(':')
+          str += '"' + parts[0].to_s + '": "' + parts[1].to_s + '",'
+        end
+        '{ ' + str.delete_suffix(',') + ' }'
+      else
+        v
+      end
+    end
 
     #########
     # Actions
@@ -93,6 +118,7 @@ module DockerCookbook
           {
             'nocache' => new_resource.nocache,
             'rm' => new_resource.rm,
+            'buildargs' => new_resource.buildargs,
           },
           connection
         )
@@ -105,6 +131,7 @@ module DockerCookbook
           {
             'nocache' => new_resource.nocache,
             'rm' => new_resource.rm,
+            'buildargs' => new_resource.buildargs,
           },
           connection
         )
@@ -117,6 +144,7 @@ module DockerCookbook
           {
             'nocache' => new_resource.nocache,
             'rm' => new_resource.rm,
+            'buildargs' => new_resource.buildargs,
           },
           connection
         )

--- a/test/cookbooks/docker_test/files/Dockerfile_5
+++ b/test/cookbooks/docker_test/files/Dockerfile_5
@@ -1,0 +1,6 @@
+ARG IMAGE_TAG
+ARG IMAGE_NAME
+FROM $IMAGE_NAME:$IMAGE_TAG
+ARG IMAGE_NAME
+ENV image_name=$IMAGE_NAME
+RUN echo $image_name > /image_name

--- a/test/cookbooks/docker_test/recipes/image.rb
+++ b/test/cookbooks/docker_test/recipes/image.rb
@@ -159,6 +159,23 @@ docker_image 'image_3' do
   action :build_if_missing
 end
 
+# build from Dockerfile with buildargs
+directory '/usr/local/src/container5' do
+  action :create
+end
+
+cookbook_file '/usr/local/src/container5/Dockerfile' do
+  source 'Dockerfile_5'
+  action :create
+end
+
+docker_image 'image_5' do
+  tag 'v0.1.0'
+  source '/usr/local/src/container5/Dockerfile'
+  buildargs '{"IMAGE_NAME":"busybox","IMAGE_TAG":"latest"}'
+  action :build_if_missing
+end
+
 #########
 # :import
 #########

--- a/test/cookbooks/docker_test/recipes/image.rb
+++ b/test/cookbooks/docker_test/recipes/image.rb
@@ -181,7 +181,7 @@ end
 docker_image 'image_5' do
   tag 'v0.1.1'
   source '/usr/local/src/container5/Dockerfile'
-  buildargs "IMAGE_NAME": "alpine", "IMAGE_TAG": "latest"
+  buildargs 'IMAGE_NAME': 'alpine', 'IMAGE_TAG': 'latest'
   action :build_if_missing
 end
 #########

--- a/test/cookbooks/docker_test/recipes/image.rb
+++ b/test/cookbooks/docker_test/recipes/image.rb
@@ -169,6 +169,7 @@ cookbook_file '/usr/local/src/container5/Dockerfile' do
   action :create
 end
 
+# String type
 docker_image 'image_5' do
   tag 'v0.1.0'
   source '/usr/local/src/container5/Dockerfile'
@@ -176,6 +177,13 @@ docker_image 'image_5' do
   action :build_if_missing
 end
 
+# Hash type
+docker_image 'image_5' do
+  tag 'v0.1.1'
+  source '/usr/local/src/container5/Dockerfile'
+  buildargs "IMAGE_NAME": "alpine", "IMAGE_TAG": "latest"
+  action :build_if_missing
+end
 #########
 # :import
 #########


### PR DESCRIPTION
# Description

Adds `buildargs` property to the `docker_image` resource.

The new property is supported in building from a Dockerfile, a directory, and a tarball.

## Issues Resolved

 #884 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
