### PR TITLE
Fix package installation on RHEL s390x architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix package installation on RHEL s390x architecture
+
 ## 7.7.0 - *2021-02-26*
 
 - Add `buildargs` property to `docker_image` resource

--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -94,8 +94,16 @@ module DockerCookbook
     action :create do
       if new_resource.setup_docker_repo
         if platform_family?('rhel', 'fedora')
-          platform = platform?('fedora') ? 'fedora' : 'centos'
           arch = node['kernel']['machine']
+          platform =
+            if platform?('fedora')
+              'fedora'
+            # s390x is only available under rhel platform
+            elsif platform?('redhat') && arch == 's390x'
+              'rhel'
+            else
+              'centos'
+            end
 
           yum_repository 'Docker' do
             baseurl "https://download.docker.com/linux/#{platform}/#{node['platform_version'].to_i}/#{arch}/#{new_resource.repo_channel}"

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -1,15 +1,90 @@
 require 'spec_helper'
 
 describe 'docker_test::installation_package' do
-  cached(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu',
-                             version: '18.04',
-                             step_into: ['docker_installation_package']).converge(described_recipe)
-  end
+  platform 'ubuntu', '18.04'
+  step_into :docker_installation_package
+  cached(:subject) { chef_run }
 
-  context 'testing default action, default properties' do
+  context 'Ubuntu: testing default action, default properties' do
     it 'installs docker' do
       expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.1')
+    end
+
+    it do
+      expect(chef_run).to add_apt_repository('Docker').with(
+        components: %w(stable),
+        uri: 'https://download.docker.com/linux/ubuntu',
+        arch: 'amd64',
+        key: %w(https://download.docker.com/linux/ubuntu/gpg)
+      )
+    end
+  end
+
+  context 'Ubuntu (aarch64): testing default action, default properties' do
+    automatic_attributes['kernel']['machine'] = 'aarch64'
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.1')
+    end
+
+    it do
+      expect(chef_run).to add_apt_repository('Docker').with(
+        components: %w(stable),
+        uri: 'https://download.docker.com/linux/ubuntu',
+        arch: 'arm64',
+        key: %w(https://download.docker.com/linux/ubuntu/gpg)
+      )
+    end
+  end
+
+  context 'Ubuntu (ppc64le): testing default action, default properties' do
+    automatic_attributes['kernel']['machine'] = 'ppc64le'
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.1')
+    end
+
+    it do
+      expect(chef_run).to add_apt_repository('Docker').with(
+        components: %w(stable),
+        uri: 'https://download.docker.com/linux/ubuntu',
+        arch: 'ppc64el',
+        key: %w(https://download.docker.com/linux/ubuntu/gpg)
+      )
+    end
+  end
+
+  context 'CentOS: testing default action, default properties' do
+    platform 'centos', '8'
+    cached(:subject) { chef_run }
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default').with(version: '3:20.10.1')
+    end
+    it do
+      expect(chef_run).to create_yum_repository('Docker').with(
+        baseurl: 'https://download.docker.com/linux/centos/8/x86_64/stable',
+        gpgkey: 'https://download.docker.com/linux/centos/gpg',
+        description: 'Docker Stable repository',
+        gpgcheck: true,
+        enabled: true
+      )
+    end
+  end
+
+  context 'CentOS (s390x): testing default action, default properties' do
+    platform 'redhat', '8'
+    cached(:subject) { chef_run }
+    automatic_attributes['kernel']['machine'] = 's390x'
+
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default').with(version: '3:20.10.1')
+    end
+    it do
+      expect(chef_run).to create_yum_repository('Docker').with(
+        baseurl: 'https://download.docker.com/linux/rhel/8/s390x/stable',
+        gpgkey: 'https://download.docker.com/linux/rhel/gpg',
+        description: 'Docker Stable repository',
+        gpgcheck: true,
+        enabled: true
+      )
     end
   end
 
@@ -19,12 +94,25 @@ describe 'docker_test::installation_package' do
   # List generated from
   # https://download.docker.com/linux/ubuntu/dists/#{distro}/stable/binary-amd64/Packages
 
-  context 'version strings for Ubuntu 18.04' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu',
-                               version: '18.04',
-                               step_into: ['docker_installation_package']).converge(described_recipe)
+  context 'version strings for Ubuntu 20.04' do
+    platform 'ubuntu', '20.04'
+    cached(:subject) { chef_run }
+
+    [
+      # Focal
+      { docker_version: '19.03.10', expected: '5:19.03.10~3-0~ubuntu-focal' },
+      { docker_version: '20.10.7', expected: '5:20.10.7~3-0~ubuntu-focal' },
+    ].each do |suite|
+      it 'generates the correct version string ubuntu focal' do
+        custom_resource = chef_run.docker_installation_package('default')
+        actual = custom_resource.version_string(suite[:docker_version])
+        expect(actual).to eq(suite[:expected])
+      end
     end
+  end
+  context 'version strings for Ubuntu 18.04' do
+    platform 'ubuntu', '18.04'
+    cached(:subject) { chef_run }
 
     [
       # Bionic
@@ -33,6 +121,7 @@ describe 'docker_test::installation_package' do
       { docker_version: '18.06.1', expected: '18.06.1~ce~3-0~ubuntu' },
       { docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-bionic' },
       { docker_version: '19.03.5', expected: '5:19.03.5~3-0~ubuntu-bionic' },
+      { docker_version: '20.10.7', expected: '5:20.10.7~3-0~ubuntu-bionic' },
     ].each do |suite|
       it 'generates the correct version string ubuntu bionic' do
         custom_resource = chef_run.docker_installation_package('default')
@@ -42,35 +131,9 @@ describe 'docker_test::installation_package' do
     end
   end
 
-  context 'version strings for Ubuntu 16.04' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu',
-                               version: '16.04',
-                               step_into: ['docker_installation_package']).converge(described_recipe)
-    end
-
-    [
-      {  docker_version: '18.03.0', expected: '18.03.0~ce-0~ubuntu' },
-      {  docker_version: '18.03.1', expected: '18.03.1~ce-0~ubuntu' },
-      {  docker_version: '18.06.0', expected: '18.06.0~ce~3-0~ubuntu' },
-      {  docker_version: '18.06.1', expected: '18.06.1~ce~3-0~ubuntu' },
-      {  docker_version: '18.09.0', expected: '5:18.09.0~3-0~ubuntu-xenial' },
-      {  docker_version: '19.03.5', expected: '5:19.03.5~3-0~ubuntu-xenial' },
-    ].each do |suite|
-      it 'generates the correct version string ubuntu xenial' do
-        custom_resource = chef_run.docker_installation_package('default')
-        actual = custom_resource.version_string(suite[:docker_version])
-        expect(actual).to eq(suite[:expected])
-      end
-    end
-  end
-
   context 'version strings for Debian 9' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'debian',
-                               version: '9',
-                               step_into: ['docker_installation_package']).converge(described_recipe)
-    end
+    platform 'debian', '9'
+    cached(:subject) { chef_run }
     [
       {  docker_version: '17.06.0', expected: '17.06.0~ce-0~debian' },
       {  docker_version: '17.06.1', expected: '17.06.1~ce-0~debian' },
@@ -94,11 +157,8 @@ describe 'docker_test::installation_package' do
   end
 
   context 'version strings for Debian 10' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'debian',
-                               version: '10',
-                               step_into: ['docker_installation_package']).converge(described_recipe)
-    end
+    platform 'debian', '10'
+    cached(:subject) { chef_run }
     [
       {  docker_version: '18.03.0', expected: '18.03.0~ce-0~debian' },
       {  docker_version: '18.03.1', expected: '18.03.1~ce-0~debian' },
@@ -111,6 +171,7 @@ describe 'docker_test::installation_package' do
       {  docker_version: '18.09.9', expected: '5:18.09.9~3-0~debian-buster' },
       {  docker_version: '19.03.0', expected: '5:19.03.0~3-0~debian-buster' },
       {  docker_version: '19.03.5', expected: '5:19.03.5~3-0~debian-buster' },
+      {  docker_version: '20.10.7', expected: '5:20.10.7~3-0~debian-buster' },
     ].each do |suite|
       it 'generates the correct version string debian stretch' do
         custom_resource = chef_run.docker_installation_package('default')


### PR DESCRIPTION
Docker provides RPMs for s390x on RHEL but _not_ CentOS (since CentOS does not include an s390x build). This provides proper logic to handle the Yum repository correctly.

Additionally, update the ChefSpec tests for the `docker_installation_package` resource with the following:

- Use newer ChefSpec coding style
- Remove tests for Ubuntu 16.04 (EOL in April 2021)
- Add tests for Ubuntu 20.04
- Add tests for yum/apt repos
- Add tests for some edge cases using other non-x86 architectures
- Update docker version string tests to include 20.10

Signed-off-by: Lance Albertson <lance@osuosl.org>
