### PR TITLE
Fix `installed_docker_version` method on ppc64le which appends `v` to the version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix `installed_docker_version` method on ppc64le which appends `v` to the version
+
 ## 7.7.1 - *2021-06-30*
 
 - Fix package installation on RHEL s390x architecture

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -58,7 +58,7 @@ module DockerCookbook
 
       def installed_docker_version
         o = shell_out("#{docker_bin} --version")
-        o.stdout.split[2].chomp(',')
+        o.stdout.split[2].chomp(',').tr('v', '')
       end
 
       def connect_host


### PR DESCRIPTION
At least on ppc64le, `docker --version` returns:

```
Docker version v20.10.7, build f0df350
```

Instead of the following on other platforms:

```
Docker version 20.10.7, build f0df350
```

This causes a problem when parsing with `Gem::Version` so this strips any `v` from the string.

Signed-off-by: Lance Albertson <lance@osuosl.org>
