### PR TITLE
docker_image :load is not idempotent without a "return if"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Ensure `docker_image :load` is idempotent
+
 ## 7.7.2 - *2021-07-01*
 
 - Fix `installed_docker_version` method on ppc64le which appends `v` to the version

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -86,6 +86,7 @@ module DockerCookbook
     end
 
     action :load do
+      return if Docker::Image.exist?(image_identifier, {}, connection)
       converge_by "load image #{image_identifier}" do
         load_image
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 
 class RSpecHelper
-  class<<self
+  class << self
     attr_accessor :current_example
   end
   def self.reset!


### PR DESCRIPTION
# Description

`docker_image :load` is not idempotent in its current form; adding a `return if` in the same vein as `:import`

## Issues Resolved

Ensure `docker_image :load` is idempotent

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
