### PR TITLE
Fixes image prune filters to match updated format

### DIFF
--- a/libraries/docker_image_prune.rb
+++ b/libraries/docker_image_prune.rb
@@ -30,11 +30,11 @@ module DockerCookbook
     end
 
     def generate_json(new_resource)
-      opts = { filters: ["dangling=#{new_resource.dangling}"] }
-      opts[:filters].push("until=#{new_resource.prune_until}") if new_resource.property_is_set?(:prune_until)
-      opts[:filters].push("label=#{new_resource.with_label}") if new_resource.property_is_set?(:with_label)
-      opts[:filters].push("label!=#{new_resource.without_label}") if new_resource.property_is_set?(:without_label)
-      opts.to_json
+      opts = { dangling: { "#{new_resource.dangling}": true } }
+      opts['until'] = { "#{new_resource.prune_until}": true } if new_resource.property_is_set?(:prune_until)
+      opts['label'] = { "#{new_resource.with_label}": true } if new_resource.property_is_set?(:with_label)
+      opts['label!'] = { "#{new_resource.without_label}": true } if new_resource.property_is_set?(:without_label)
+      'filters=' + URI.encode_www_form_component(opts.to_json)
     end
   end
 end

--- a/test/cookbooks/docker_test/recipes/image_prune.rb
+++ b/test/cookbooks/docker_test/recipes/image_prune.rb
@@ -6,6 +6,10 @@ docker_image_prune 'hello-world' do
   dangling true
 end
 
+docker_image_prune 'prune-tagged-unused' do
+  dangling false
+end
+
 docker_image_prune 'prune-old-images' do
   dangling true
   prune_until '1h30m'


### PR DESCRIPTION
# Description

Right now image prune only removes unused and untagged image, or dangling true.
Setting to false has no effect as Docker API now expects filters in URL Encoded Form string.
This change fixes filters.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
