### PR TITLE
Disable installation-script-main suite on Debian 9 due to lack of upstream support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
           - 'installation-package'
           - 'installation-tarball'
           - 'smoke'
+        exclude:
+          - os: debian-9
+            suite: installation-script-main
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Disable installation-script-main suite on Debian 9 due to lack of upstream support
+
 ## 7.7.4 - *2021-08-24*
 
 ## 7.7.3 - *2021-07-17*

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -34,6 +34,7 @@ suites:
   - name: installation_script_main
     excludes:
       - 'amazonlinux-2'
+      - 'debian-9'
     attributes:
       docker:
         repo: 'main'


### PR DESCRIPTION
This should fix tests that are currently failing.

Signed-off-by: Lance Albertson <lance@osuosl.org>
