### PR TITLE
#1186: Update and sync log drivers for service and container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- update and sync log drivers list for docker_service_manager and docker_container
+
 ## 8.3.0 - *2021-09-13*
 
 - Remove Ubuntu 16.04 from the GitHub Actions test matrix

--- a/documentation/docker_container.md
+++ b/documentation/docker_container.md
@@ -47,7 +47,7 @@ Most `docker_container` properties are the `snake_case` version of the `CamelCas
 - `host_name` - The hostname for the container.
 - `labels` A string, array, or hash to set metadata on the container in the form ['foo:bar', 'hello:world']`
 - `links` - An array of source container/alias pairs to link the container to in the form `[container_a:www', container_b:db']`
-- `log_driver` - Sets a custom logging driver for the container (json-file/syslog/journald/gelf/fluentd/none).
+- `log_driver` - Sets a custom logging driver for the container (json-file/syslog/journald/gelf/fluentd/awslogs/splunk/etwlogs/gcplogs/logentries/loki-docker/local/none).
 - `log_opts` - Configures the above logging driver options (driver-specific).
 - `init` - Run an init inside the container that forwards signals and reaps processes.
 - `ip_address` - Container IPv4 address (e.g. 172.30.100.104)

--- a/documentation/docker_service.md
+++ b/documentation/docker_service.md
@@ -66,7 +66,7 @@ The `docker_service` resource property list mostly corresponds to the options fo
 - `ipv6_forward` - Enable net.ipv6.ip_forward
 - `ipv6` - Enable IPv6 networking
 - `labels` A string or array to set metadata on the daemon in the form ['foo:bar', 'hello:world']`
-- `log_driver` - Container's logging driver (json-file/syslog/journald/gelf/fluentd/awslogs/splunk/etwlogs/gcplogs/none)
+- `log_driver` - Container's logging driver (json-file/syslog/journald/gelf/fluentd/awslogs/splunk/etwlogs/gcplogs/logentries/loki-docker/local/none)
 - `log_level` - Set the logging level
 - `log_opts` - Container's logging driver options (driver-specific)
 - `logfile` - Location of Docker daemon log file

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -35,7 +35,7 @@ module DockerCookbook
     property :kernel_memory, [String, Integer], coerce: proc { |v| coerce_to_bytes(v) }, default: 0
     property :labels, [String, Array, Hash], default: {}, coerce: proc { |v| coerce_labels(v) }
     property :links, UnorderedArrayType, coerce: proc { |v| coerce_links(v) }
-    property :log_driver, %w( json-file syslog journald gelf fluentd awslogs splunk loki-docker etwlogs gcplogs none local ), default: 'json-file', desired_state: false
+    property :log_driver, %w( json-file syslog journald gelf fluentd awslogs splunk loki-docker etwlogs gcplogs logentries none local ), default: 'json-file', desired_state: false
     property :log_opts, [Hash, nil], coerce: proc { |v| coerce_log_opts(v) }, desired_state: false
     property :init, [TrueClass, FalseClass, nil]
     property :ip_address, String

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -51,7 +51,7 @@ module DockerCookbook
     property :default_ip_address_pool, String
     property :log_level, %w(debug info warn error fatal)
     property :labels, [String, Array], coerce: proc { |v| coerce_daemon_labels(v) }, desired_state: false
-    property :log_driver, %w(json-file syslog journald gelf fluentd awslogs splunk none local)
+    property :log_driver, %w(json-file syslog journald gelf fluentd awslogs splunk etwlogs gcplogs logentries loki-docker none local)
     property :log_opts, [String, Array], coerce: proc { |v| v.nil? ? nil : Array(v) }
     property :mount_flags, String
     property :mtu, String


### PR DESCRIPTION
# Description

Accepted log drivers for `docker_container` and `docker_service_manager` were different and out of date.
Add all supported logging drivers ([Docker Logging Docs](https://docs.docker.com/config/containers/logging/configure/#supported-logging-drivers)) and loki-docker as it was already supported for `docker_container` to both resouces.

## Issues Resolved

#1186  

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
