### PR TITLE
update exec resource to use partial/_base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 9.6.1 - *2021-09-20*
+
+- Update exec resource to use partial/_base
+
 ## 9.6.0 - *2021-09-16*
 
 - Move the docker_plugin library to a custom resource

--- a/resources/exec.rb
+++ b/resources/exec.rb
@@ -1,4 +1,5 @@
 unified_mode true
+use 'partial/_base'
 
 property :host, [String, nil], default: lazy { ENV['DOCKER_HOST'] }, desired_state: false
 property :command, Array


### PR DESCRIPTION
# Description

docker_exec is currently failing following the move from a library to resource due to not using partial/_base

## Issues Resolved

I opened this instead of opening an issue ;)

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
