### PR TITLE
Fix group resource for `docker_installation_tarball` library in #1205

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix group resource for `docker_installation_tarball` library in #1205 [@benpro](https://github.com/benpro)
+
 ## 10.1.1 - *2021-11-03*
 
 - Add CentOS Stream 8 to CI pipeline

--- a/libraries/docker_installation_tarball.rb
+++ b/libraries/docker_installation_tarball.rb
@@ -83,6 +83,7 @@ module DockerCookbook
 
       group 'docker' do
         system true
+        append true
       end
     end
 


### PR DESCRIPTION
# Description

Adding the property `append true` is required to not reset members within
docker group at each converge.

## Issues Resolved

- #1205

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
