### PR TITLE
Update to tarball checksums to 20.10.11 and 19.03.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Update to tarball checksums to 20.10.11 and 19.03.15
+- Update to using version 20.10.11 for testing suites
+
 ## 10.1.2 - *2021-11-16*
 
 - Fix group resource for `docker_installation_tarball` library in #1205 [@benpro](https://github.com/benpro)

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The `docker_installation_package` resource uses the system package manager to in
 
 ```ruby
 docker_installation_package 'default' do
-  version '20.10.1'
+  version '20.10.11'
   action :create
   package_options %q|--force-yes -o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-all'| # if Ubuntu for example
 end

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -73,7 +73,7 @@ suites:
       multiple_converge: 1
     attributes:
       docker:
-        version: '20.10.1'
+        version: '20.10.11'
     run_list:
       - recipe[docker_test::default]
       - recipe[docker_test::image]
@@ -87,7 +87,7 @@ suites:
       multiple_converge: 1
     attributes:
       docker:
-        version: '20.10.1'
+        version: '20.10.11'
     run_list:
       - recipe[docker_test::default]
       - recipe[docker_test::network]
@@ -98,7 +98,7 @@ suites:
       multiple_converge: 1
     attributes:
       docker:
-        version: '20.10.1'
+        version: '20.10.11'
     run_list:
       - recipe[docker_test::default]
       - recipe[docker_test::volume]
@@ -109,7 +109,7 @@ suites:
       multiple_converge: 1
     attributes:
       docker:
-        version: '20.10.1'
+        version: '20.10.11'
     run_list:
       - recipe[docker_test::default]
       - recipe[docker_test::registry]

--- a/libraries/docker_installation_tarball.rb
+++ b/libraries/docker_installation_tarball.rb
@@ -6,7 +6,7 @@ module DockerCookbook
     property :checksum, String, default: lazy { default_checksum }, desired_state: false
     property :source, String, default: lazy { default_source }, desired_state: false
     property :channel, String, default: 'stable', desired_state: false
-    property :version, String, default: '20.10.1', desired_state: false
+    property :version, String, default: '20.10.11', desired_state: false
 
     ##################
     # Property Helpers
@@ -44,16 +44,16 @@ module DockerCookbook
         when '18.03.1' then 'bbfb9c599a4fdb45523496c2ead191056ff43d6be90cf0e348421dd56bc3dcf0'
         when '18.06.3' then 'f7347ef27db9a438b05b8f82cd4c017af5693fe26202d9b3babf750df3e05e0c'
         when '18.09.9' then 'ed83a3d51fef2bbcdb19d091ff0690a233aed4bbb47d2f7860d377196e0143a0'
-        when '19.03.14' then '7fbf94a39f0034035c129ca7463234263015e97f7e5747beaf6a8ba9e535e0c3'
-        when '20.10.1' then 'bfcbfa86b7df1c1312293ccf7faf29dd55ec501e5bbdc9cb38eb47ed976e554c'
+        when '19.03.15' then '61672045675798b2075d4790665b74336c03b6d6084036ef22720af60614e50d'
+        when '20.10.11' then '8f338ba618438fa186d1fa4eae32376cca58f86df2b40b5027c193202fad2acf'
         end
       when 'Linux'
         case version
         when '18.03.1' then '0e245c42de8a21799ab11179a4fce43b494ce173a8a2d6567ea6825d6c5265aa'
         when '18.06.3' then '346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822'
         when '18.09.9' then '82a362af7689038c51573e0fd0554da8703f0d06f4dfe95dd5bda5acf0ae45fb'
-        when '19.03.14' then '9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847'
-        when '20.10.1' then '8790f3b94ee07ca69a9fdbd1310cbffc729af0a07e5bf9f34a79df1e13d2e50e'
+        when '19.03.15' then '5504d190eef37355231325c176686d51ade6e0cabe2da526d561a38d8611506f'
+        when '20.10.11' then 'dd6ff72df1edfd61ae55feaa4aadb88634161f0aa06dbaaf291d1be594099ff3'
         end
       end
     end

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -7,7 +7,7 @@ describe 'docker_test::installation_package' do
 
   context 'Ubuntu: testing default action, default properties' do
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.1')
+      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.11')
     end
 
     it do
@@ -23,7 +23,7 @@ describe 'docker_test::installation_package' do
   context 'Ubuntu (aarch64): testing default action, default properties' do
     automatic_attributes['kernel']['machine'] = 'aarch64'
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.1')
+      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.11')
     end
 
     it do
@@ -39,7 +39,7 @@ describe 'docker_test::installation_package' do
   context 'Ubuntu (ppc64le): testing default action, default properties' do
     automatic_attributes['kernel']['machine'] = 'ppc64le'
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.1')
+      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.11')
     end
 
     it do
@@ -56,7 +56,7 @@ describe 'docker_test::installation_package' do
     platform 'centos', '8'
     cached(:subject) { chef_run }
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '3:20.10.1')
+      expect(chef_run).to create_docker_installation_package('default').with(version: '3:20.10.11')
     end
     it do
       expect(chef_run).to create_yum_repository('Docker').with(
@@ -75,7 +75,7 @@ describe 'docker_test::installation_package' do
     automatic_attributes['kernel']['machine'] = 's390x'
 
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '3:20.10.1')
+      expect(chef_run).to create_docker_installation_package('default').with(version: '3:20.10.11')
     end
     it do
       expect(chef_run).to create_yum_repository('Docker').with(

--- a/test/cookbooks/docker_test/recipes/installation_package.rb
+++ b/test/cookbooks/docker_test/recipes/installation_package.rb
@@ -1,12 +1,12 @@
 docker_ver =
   # Include epoch on RHEL to fix idempotency issues
   if platform_family?('rhel', 'fedora')
-    '3:20.10.1'
+    '3:20.10.11'
   # Debian 9 does not include 20.10
   elsif platform?('debian') && node['platform_version'].to_i == 9
     '19.03.14'
   else
-    '20.10.1'
+    '20.10.11'
   end
 
 docker_installation_package 'default' do

--- a/test/cookbooks/docker_test/recipes/installation_tarball.rb
+++ b/test/cookbooks/docker_test/recipes/installation_tarball.rb
@@ -1,3 +1,3 @@
 docker_installation_tarball 'default' do
-  version '20.10.1'
+  version '20.10.11'
 end

--- a/test/integration/installation_tarball/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_tarball/inspec/assert_functioning_spec.rb
@@ -1,6 +1,6 @@
 describe command '/usr/bin/docker --version' do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should match(/20.10.1/) }
+  its(:stdout) { should match(/20.10.11/) }
 end
 
 describe group 'docker' do

--- a/test/integration/resources/inspec/assert_functioning_spec.rb
+++ b/test/integration/resources/inspec/assert_functioning_spec.rb
@@ -10,7 +10,7 @@ chef_dir = file('/opt/cinc').exist? ? '/opt/cinc' : '/opt/chef'
 # docker_service[default]
 
 describe docker.version do
-  its('Server.Version') { should eq '20.10.1' }
+  its('Server.Version') { should eq '20.10.11' }
 end
 
 describe command('docker info') do


### PR DESCRIPTION
Also update to using version 20.10.11 for testing suites. This is needed for #1208 to pass properly.

Signed-off-by: Lance Albertson <lance@osuosl.org>
