### PR TITLE
Fix raise when using mixed address families with a network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix raise when using mixed address families with a network
+
 ## 10.1.3 - *2021-12-01*
 
 - Update to tarball checksums to 20.10.11 and 19.03.15

--- a/resources/network.rb
+++ b/resources/network.rb
@@ -268,6 +268,11 @@ action_class do
   end
 
   def subnet_matches(subnet, data)
-    IPAddress(subnet).include?(IPAddress(data))
+    s = IPAddress(subnet)
+    d = IPAddress(data)
+
+    return false unless s.class.eql?(d.class)
+
+    s.include?(d)
   end
 end


### PR DESCRIPTION
# Description

- Fix raise when using mixed address families with a network

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
