### PR TITLE
Fix generate_json not accepting a variable number of arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix `generate_json` not accepting a variable number of arguments
+
 ## 10.1.4 - *2021-12-05*
 
 - Fix raise when using mixed address families with a network

--- a/libraries/helpers_json.rb
+++ b/libraries/helpers_json.rb
@@ -1,11 +1,11 @@
 module DockerCookbook
   module DockerHelpers
     module Json
-      def generate_json(dangling, prune_until, with_label, without_label)
+      def generate_json(dangling, prune_until = nil, with_label = nil, without_label = nil)
         opts = { dangling: { "#{dangling}": true } }
-        opts['until'] = { "#{prune_until}": true } unless prune_until == nil?
-        opts['label'] = { "#{with_label}": true } unless with_label == nil?
-        opts['label!'] = { "#{without_label}": true } unless without_label == nil?
+        opts['until'] = { "#{prune_until}": true } if prune_until
+        opts['label'] = { "#{with_label}": true } if with_label
+        opts['label!'] = { "#{without_label}": true } if without_label
         'filters=' + URI.encode_www_form_component(opts.to_json)
       end
     end


### PR DESCRIPTION
# Description

Fix generate_json not accepting a variable number of arguments

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
