### PR TITLE
Sort container volume_binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Sort container volume_binds to prevent erroneous container re-deploys
+
 ## 10.2.0 - *2022-08-19*
 
 - Don't set container swappiness with cgroupv2

--- a/resources/container.rb
+++ b/resources/container.rb
@@ -75,7 +75,7 @@ property :volume_driver, String
 property :working_dir, String
 
 # Used to store the bind property since binds is an alias to volumes
-property :volumes_binds, Array
+property :volumes_binds, Array, coerce: proc { |v| v.sort }
 
 # Used to store the state of the Docker container
 property :container, Docker::Container, desired_state: false


### PR DESCRIPTION
# Description

Sort container volume_binds to prevent containers being re-deployed erroneously as docker may return the volume_binds in a different order to how they are specified as a resource property.

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
