### PR TITLE
Fix arguments to generate_json in docker_image_prune resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix arguments to generate_json in docker_image_prune resource
+
 ## 10.2.1 - *2022-10-07*
 
 - Sort container volume_binds to prevent erroneous container re-deploys

--- a/resources/image_prune.rb
+++ b/resources/image_prune.rb
@@ -14,7 +14,7 @@ property :without_label, String
 action :prune do
   # Have to call this method ourselves due to
   # https://github.com/swipely/docker-api/pull/507
-  json = generate_json(new_resource)
+  json = generate_json(new_resource.dangling, new_resource.prune_until, new_resource.with_label, new_resource.without_label)
 
   res = connection.post('/images/prune', json)
   Chef::Log.info res


### PR DESCRIPTION
Signed-off-by: Hans Rakers <h.rakers@global.leaseweb.com>

# Description

This PR fixes the arguments passed to `generate_json` in the docker_image_prune resource

## Issues Resolved

List any existing issues this PR resolves

#1216

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
