### PR TITLE
docker_installation_package: support for ubuntu 22.04

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -60,6 +60,11 @@ module DockerCookbook
       false
     end
 
+    def jammy?
+      return true if platform?('ubuntu') && node['platform_version'] == '22.04'
+      false
+    end
+
     # https://github.com/chef/chef/issues/4103
     def version_string(v)
       return if v.nil?
@@ -73,6 +78,8 @@ module DockerCookbook
                    'bionic'
                  elsif focal? # ubuntu 20.04
                    'focal'
+                 elsif jammy? # ubuntu 22.04
+                   'jammy'
                  end
 
       # https://github.com/seemethere/docker-ce-packaging/blob/9ba8e36e8588ea75209d813558c8065844c953a0/deb/gen-deb-ver#L16-L20


### PR DESCRIPTION
# Description

Support Ubuntu 22.04 for module docker_installation_package

## Issues Resolved

Resolving
[1224](https://github.com/sous-chefs/docker/issues/1224)
## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
