### PR TITLE
set lsb codename

### DIFF
--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -138,6 +138,7 @@ module DockerCookbook
 
           apt_repository 'Docker' do
             components Array(new_resource.repo_channel)
+            distribution node['lsb']['codename']
             uri "https://download.docker.com/linux/#{node['platform']}"
             arch deb_arch
             key "https://download.docker.com/linux/#{node['platform']}/gpg"

--- a/libraries/docker_installation_package.rb
+++ b/libraries/docker_installation_package.rb
@@ -65,22 +65,26 @@ module DockerCookbook
       false
     end
 
-    # https://github.com/chef/chef/issues/4103
+    def debian_codename
+      if stretch? # deb 9
+        'stretch'
+      elsif buster? # deb 10
+        'buster'
+      elsif bullseye? # deb 11
+        'bullseye'
+      elsif bionic? # ubuntu 18.04
+        'bionic'
+      elsif focal? # ubuntu 20.04
+        'focal'
+      elsif jammy? # ubuntu 22.04
+        'jammy'
+      end
+    end
+
     def version_string(v)
       return if v.nil?
-      codename = if stretch? # deb 9
-                   'stretch'
-                 elsif buster? # deb 10
-                   'buster'
-                 elsif bullseye? # deb 11
-                   'bullseye'
-                 elsif bionic? # ubuntu 18.04
-                   'bionic'
-                 elsif focal? # ubuntu 20.04
-                   'focal'
-                 elsif jammy? # ubuntu 22.04
-                   'jammy'
-                 end
+    # https://github.com/chef/chef/issues/4103
+      codename = debian_codename
 
       # https://github.com/seemethere/docker-ce-packaging/blob/9ba8e36e8588ea75209d813558c8065844c953a0/deb/gen-deb-ver#L16-L20
       test_version = '3'
@@ -138,7 +142,7 @@ module DockerCookbook
 
           apt_repository 'Docker' do
             components Array(new_resource.repo_channel)
-            distribution node['lsb']['codename']
+            distribution debian_codename
             uri "https://download.docker.com/linux/#{node['platform']}"
             arch deb_arch
             key "https://download.docker.com/linux/#{node['platform']}/gpg"


### PR DESCRIPTION
# Description

```
    Mixlib::ShellOut::ShellCommandFailed                                                                                             
    ------------------------------------                                                                                             
    Expected process to exit with [0], but received '100'                                                                            
    ---- Begin output of ["apt-cache", "policy", "apt-transport-https"] ----                                                         
    STDOUT:                                                                                                                          
    STDERR: E: Malformed entry 1 in list file /etc/apt/sources.list.d/Docker.list (Component)                                        
    E: The list of sources could not be read.                                                                                        
    ---- End output of ["apt-cache", "policy", "apt-transport-https"] ----                                                           
    Ran ["apt-cache", "policy", "apt-transport-https"] returned 100  

```
I realized the above errror when executing `cinc-client(localmode)`
It is apt source when happend error.

```
# cat sources.list.d/Docker.list                                                                            
deb      [arch=amd64] https://download.docker.com/linux/ubuntu stable 
```
then, I fixed it due to setting destribution attributes.
please check it.

## Issues Resolved
https://github.com/sous-chefs/docker/issues/1207
List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
