### PR TITLE
[GH-1248] only pass common properties to service manager resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Only pass common resource properties of the `docker_service`-resource to
+  the specific service manager resources.
+
 ## 11.0.0 - *2023-05-29*
 
 - Update to work on Chef 18 in unified mode, fixes #1222 [@b-dean](https://github.com/b-dean)

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -66,7 +66,8 @@ action_class do
 
   def svc_manager(&block)
     b = proc {
-      copy_properties_from(new_resource, exclude: [:service_manager, :install_method])
+      copy_properties_from(new_resource, *property_intersection(new_resource, self),
+                           exclude: [:service_manager, :install_method])
       instance_exec(&block)
     }
 


### PR DESCRIPTION
# Description

This PR fixes a bug, that properties of the `docker_service`-resource were passed to specific service management resource, which weren't defined there.

## Issues Resolved

* #1248

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] ~~New functionality includes testing.~~
- [ ] ~~New functionality has been documented in the README if applicable.~~
