### PR TITLE
publish_all_ports can either be true or false

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -731,7 +731,7 @@ module DockerCookbook
                !(new_resource.extra_hosts.nil? || new_resource.extra_hosts.empty?) ||
                !(new_resource.exposed_ports.nil? || new_resource.exposed_ports.empty?) ||
                !(new_resource.port_bindings.nil? || new_resource.port_bindings.empty?) ||
-               !(new_resource.publish_all_ports.nil? || new_resource.publish_all_ports.empty?) ||
+               new_resource.publish_all_ports ||
                !new_resource.port.nil?
            )
           raise Chef::Exceptions::ValidationFailed, 'Cannot specify hostname, dns, dns_search, mac_address, extra_hosts, exposed_ports, port_bindings, publish_all_ports, port when network_mode is container.'


### PR DESCRIPTION
# Description

publish_all_ports property can either be True/False when setting network_mode to 'container' this condition fails because `.empty?` does not exist on True/FalseClass. 

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
