### PR TITLE
Add download website property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add site_url property to docker_installation_package resource
+  
 ## 11.3.1 - *2024-02-15*
 
 ## 11.3.0 - *2023-10-12*

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -118,7 +118,7 @@ action :create do
 
       yum_repository 'Docker' do
         baseurl "https://#{new_resource.site_url}/linux/#{platform}/#{node['platform_version'].to_i}/#{arch}/#{new_resource.repo_channel}"
-        gpgkey "https://#{new_resource.site_url}linux/#{platform}/gpg"
+        gpgkey "https://#{new_resource.site_url}/linux/#{platform}/gpg"
         description "Docker #{new_resource.repo_channel.capitalize} repository"
         gpgcheck true
         enabled true

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -10,6 +10,7 @@ property :package_name, String, default: 'docker-ce', desired_state: false
 property :package_version, String, desired_state: false
 property :version, String, desired_state: false
 property :package_options, String, desired_state: false
+property :site_url, String, default: 'download.docker.com'
 
 def el7?
   return true if platform_family?('rhel') && node['platform_version'].to_i == 7
@@ -116,8 +117,8 @@ action :create do
         end
 
       yum_repository 'Docker' do
-        baseurl "https://download.docker.com/linux/#{platform}/#{node['platform_version'].to_i}/#{arch}/#{new_resource.repo_channel}"
-        gpgkey "https://download.docker.com/linux/#{platform}/gpg"
+        baseurl "https://#{new_resource.site_url}/linux/#{platform}/#{node['platform_version'].to_i}/#{arch}/#{new_resource.repo_channel}"
+        gpgkey "https://#{new_resource.site_url}linux/#{platform}/gpg"
         description "Docker #{new_resource.repo_channel.capitalize} repository"
         gpgcheck true
         enabled true
@@ -141,9 +142,9 @@ action :create do
 
       apt_repository 'Docker' do
         components Array(new_resource.repo_channel)
-        uri "https://download.docker.com/linux/#{node['platform']}"
+        uri "https://#{new_resource.site_url}/linux/#{node['platform']}"
         arch deb_arch
-        key "https://download.docker.com/linux/#{node['platform']}/gpg"
+        key "https://#{new_resource.site_url}/linux/#{node['platform']}/gpg"
         action :add
       end
     else


### PR DESCRIPTION
# Description

external website is not always available to all company due to firewall, security, etc.
Usually artifactory or other proxy to put in front to cache remote artifacts

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
