### PR TITLE
Bump docker-api gem dep to >= 2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,12 @@ jobs:
       matrix:
         os:
           - "almalinux-8"
-          - "centos-7"
-          - "centos-stream-8"
-          - "debian-10"
           - "debian-11"
+          - "debian-12"
           - "rockylinux-8"
-          - "ubuntu-1804"
+          - "rockylinux-9"
           - "ubuntu-2004"
+          - "ubuntu-2204"
         suite:
           - "installation-script-main"
           - "installation-script-test"
@@ -38,10 +37,10 @@ jobs:
           - "installation-tarball"
           - "install-and-stop"
         exclude:
-          - os: debian-9
-            suite: installation-script-main
           - os: debian-11
             suite: installation-script-test
+          - os: debian-12
+            suite: installation-script-test
           - os: almalinux-8
             suite: installation-script-main
           - os: almalinux-8
@@ -49,6 +48,10 @@ jobs:
           - os: rockylinux-8
             suite: installation-script-main
           - os: rockylinux-8
+            suite: installation-script-test
+          - os: rockylinux-9
+            suite: installation-script-main
+          - os: rockylinux-9
             suite: installation-script-test
       fail-fast: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Bump `docker-api` dependency to `>= 2.3` to fix [upstream bug #586](https://github.com/upserve/docker-api/issues/586)
+
 ## 11.3.6 - *2024-07-08*
 
 - Version bump to force a release

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -22,11 +22,6 @@ platforms:
       image: dokken/amazonlinux-2023
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-stream-8
-    driver:
-      image: dokken/centos-stream-8
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-stream-9
     driver:
       image: dokken/centos-stream-9

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -18,7 +18,6 @@ platforms:
   - name: almalinux-8
   - name: almalinux-9
   - name: amazonlinux-2023
-  - name: centos-stream-8
   - name: centos-stream-9
   - name: debian-11
   - name: debian-12

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -20,7 +20,6 @@ platforms:
   - name: almalinux-8
   - name: amazonlinux-2
   - name: centos-7
-  - name: centos-stream-8
   - name: debian-10
     # docker post-install script misbehaves on Debian 10 if systemd isn't completely started
     # https://forums.docker.com/t/failed-to-load-listeners-no-sockets-found-via-socket-activation-make-sure-the-service-was-started-by-systemd/62505/11

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,5 +17,4 @@ supports 'fedora'
 supports 'redhat'
 supports 'ubuntu'
 
-gem 'docker-api', '>= 1.34', '< 3'
-gem 'excon', '0.110.0'
+gem 'docker-api', '>= 2.3', '< 3'

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -52,6 +52,11 @@ def bullseye?
   false
 end
 
+def bookworm?
+  return true if platform?('debian') && node['platform_version'].to_i == 11
+  false
+end
+
 def bionic?
   return true if platform?('ubuntu') && node['platform_version'] == '18.04'
   false
@@ -76,6 +81,8 @@ def version_string(v)
                'buster'
              elsif bullseye? # deb 11
                'bullseye'
+             elsif bookworm? # deb 12
+               'bookworm'
              elsif bionic? # ubuntu 18.04
                'bionic'
              elsif focal? # ubuntu 20.04

--- a/test/integration/install_and_stop/inspec/assert_functioning_spec.rb
+++ b/test/integration/install_and_stop/inspec/assert_functioning_spec.rb
@@ -1,18 +1,22 @@
-# Debian 9 does not include 23.0
-if os.name == 'debian' && os.release.to_i == 9
+if os.name == 'debian'
   describe command('/usr/bin/docker --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/19\.03\./) }
+    its(:stdout) { should match(/27\.0\./) }
   end
 elsif os.name == 'amazon' && %w(2 2023).include?(os.release)
   describe command('/usr/bin/docker --version') do
     its(:exit_status) { should eq 0 }
     its(:stdout) { should match(/20\.10\./) }
   end
+elsif os.family == 'redhat' && os.release.to_i == 8
+  describe command('/usr/bin/docker --version') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(/26\.1\./) }
+  end
 else
   describe command('/usr/bin/docker --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/24\.0\./) }
+    its(:stdout) { should match(/27\.0\./) }
   end
 end
 

--- a/test/integration/installation_package/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_package/inspec/assert_functioning_spec.rb
@@ -1,12 +1,11 @@
-# Debian 9 does not include 20.10
-if os.name == 'debian' && os.release.to_i == 9
+if os.family == 'redhat' && os.release.to_i == 8
   describe command('/usr/bin/docker --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/19\.03\./) }
+    its(:stdout) { should match(/26\.1\./) }
   end
 else
   describe command('/usr/bin/docker --version') do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/24\.0\./) }
+    its(:stdout) { should match(/27\.1\./) }
   end
 end


### PR DESCRIPTION
# Description

Bump docker-api gem dep to >= 2.3

## Issues Resolved

- n/a

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
