### PR TITLE
Use correct Debian Bookworm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix `version_string` for Debian Bookworm
+
 ## 11.4.0 - *2024-07-15*
 
 - `docker_installation_package` support for Ubuntu v24.04 (noble)

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -53,7 +53,7 @@ def bullseye?
 end
 
 def bookworm?
-  return true if platform?('debian') && node['platform_version'].to_i == 11
+  return true if platform?('debian') && node['platform_version'].to_i == 12
   false
 end
 


### PR DESCRIPTION
# Description

Fixes the `version_string` for Debian Bookworm.

## Issues Resolved


## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
