### PR TITLE
Add none as an option to service_manager to allow using the system defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
       matrix:
         os:
           - "almalinux-8"
+          - "almalinux-9"
           - "debian-11"
           - "debian-12"
           - "rockylinux-8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,17 +100,15 @@ jobs:
 
   integration-smoke:
     needs: lint-unit
-    runs-on: macos-latest
+    runs-on: macos-12
     strategy:
       matrix:
         os:
           - "almalinux-8"
-          - "centos-7"
-          - "centos-stream-8"
-          - "debian-10"
           - "debian-11"
+          - "debian-12"
           - "rockylinux-8"
-          - "ubuntu-1804"
+          - "rockylinux-9"
           - "ubuntu-2004"
           - "ubuntu-2204"
           - "ubuntu-2404"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
   integration-smoke:
     needs: lint-unit
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
@@ -119,6 +119,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Install VirtualBox & Vagrant
+        run: |
+          sudo apt update && sudo apt install virtualbox
+          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update && sudo apt install vagrant
       - name: Install Chef
         uses: actionshub/chef-install@3.0.0
       - name: Dokken

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Add `none` as an option to `service_manager` to allow using the system defaults
+- Switch to running vagrant+virtualbox on Ubuntu via nested virtualization for smoke tests
+- Fix package installation tests
 
 ## 11.4.2 - *2024-07-16*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add `none` as an option to `service_manager` to allow using the system defaults
+
 ## 11.4.2 - *2024-07-16*
 
 ## 11.4.1 - *2024-07-16*

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,22 +19,14 @@ verifier:
 
 platforms:
   - name: almalinux-8
-  - name: amazonlinux-2
-  - name: centos-7
-  - name: debian-10
-    # docker post-install script misbehaves on Debian 10 if systemd isn't completely started
-    # https://forums.docker.com/t/failed-to-load-listeners-no-sockets-found-via-socket-activation-make-sure-the-service-was-started-by-systemd/62505/11
-    lifecycle:
-      pre_converge:
-        - remote: 'until systemctl --quiet is-active multi-user.target; do sleep 2; done'
+  - name: almalinux-9
   - name: debian-11
-  - name: fedora-latest
+  - name: debian-12
   - name: rockylinux-8
-  - name: ubuntu-18.04
-    lifecycle:
-      pre_converge:
-        - remote: sudo apt update
+  - name: rockylinux-9
   - name: ubuntu-20.04
+  - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 suites:
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -8,7 +8,7 @@ driver:
 provisioner:
   name: chef_infra
   product_name: <%= ENV['CHEF_PRODUCT_NAME'] || 'chef' %>
-  product_version: <%= ENV['CHEF_VERSION'] || '18' %>
+  product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -8,10 +8,11 @@ driver:
 provisioner:
   name: chef_infra
   product_name: <%= ENV['CHEF_PRODUCT_NAME'] || 'chef' %>
-  product_version: <%= ENV['CHEF_VERSION'] || '17' %>
+  product_version: <%= ENV['CHEF_VERSION'] || '18' %>
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -9,7 +9,7 @@ provides :docker_service
 
 # installation type and service_manager
 property :install_method, %w(script package tarball none auto), default: lazy { docker_install_method }, desired_state: false
-property :service_manager, %w(execute systemd auto), default: 'auto', desired_state: false
+property :service_manager, %w(execute systemd none auto), default: 'auto', desired_state: false
 
 # docker_installation_script
 property :repo, String, desired_state: false
@@ -78,6 +78,9 @@ action_class do
       svc = docker_service_manager_execute(new_resource.name, &b)
     when 'systemd'
       svc = docker_service_manager_systemd(new_resource.name, &b)
+    when 'none'
+      Chef::Log.info('Skipping Docker Server Manager. Assuming it was handled previously.')
+      return
     end
     svc
   end

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe 'docker_test::installation_package' do
-  platform 'ubuntu', '18.04'
+  platform 'ubuntu'
   step_into :docker_installation_package
   cached(:subject) { chef_run }
 
   context 'Ubuntu: testing default action, default properties' do
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.11')
+      expect(chef_run).to create_docker_installation_package('default')
     end
 
     it do
@@ -23,7 +23,7 @@ describe 'docker_test::installation_package' do
   context 'Ubuntu (aarch64): testing default action, default properties' do
     automatic_attributes['kernel']['machine'] = 'aarch64'
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.11')
+      expect(chef_run).to create_docker_installation_package('default')
     end
 
     it do
@@ -39,7 +39,7 @@ describe 'docker_test::installation_package' do
   context 'Ubuntu (ppc64le): testing default action, default properties' do
     automatic_attributes['kernel']['machine'] = 'ppc64le'
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '20.10.11')
+      expect(chef_run).to create_docker_installation_package('default')
     end
 
     it do
@@ -53,10 +53,10 @@ describe 'docker_test::installation_package' do
   end
 
   context 'CentOS: testing default action, default properties' do
-    platform 'centos', '8'
+    platform 'centos'
     cached(:subject) { chef_run }
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '3:20.10.11')
+      expect(chef_run).to create_docker_installation_package('default')
     end
     it do
       expect(chef_run).to create_yum_repository('Docker').with(
@@ -75,7 +75,7 @@ describe 'docker_test::installation_package' do
     automatic_attributes['kernel']['machine'] = 's390x'
 
     it 'installs docker' do
-      expect(chef_run).to create_docker_installation_package('default').with(version: '3:20.10.11')
+      expect(chef_run).to create_docker_installation_package('default')
     end
     it do
       expect(chef_run).to create_yum_repository('Docker').with(

--- a/test/cookbooks/docker_test/recipes/installation_package.rb
+++ b/test/cookbooks/docker_test/recipes/installation_package.rb
@@ -1,15 +1,3 @@
-docker_ver =
-  # Include epoch on RHEL to fix idempotency issues
-  if platform_family?('rhel', 'fedora')
-    '3:20.10.11'
-  # Debian 9 does not include 20.10
-  elsif platform?('debian') && node['platform_version'].to_i == 9
-    '19.03.14'
-  else
-    '20.10.11'
-  end
-
 docker_installation_package 'default' do
-  version docker_ver
   action :create
 end

--- a/test/integration/install_and_stop/inspec/assert_functioning_spec.rb
+++ b/test/integration/install_and_stop/inspec/assert_functioning_spec.rb
@@ -1,23 +1,6 @@
-if os.name == 'debian'
-  describe command('/usr/bin/docker --version') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/27\.0\./) }
-  end
-elsif os.name == 'amazon' && %w(2 2023).include?(os.release)
-  describe command('/usr/bin/docker --version') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/20\.10\./) }
-  end
-elsif os.family == 'redhat' && os.release.to_i == 8
-  describe command('/usr/bin/docker --version') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/26\.1\./) }
-  end
-else
-  describe command('/usr/bin/docker --version') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/27\.0\./) }
-  end
+describe command('/usr/bin/docker --version') do
+  its(:exit_status) { should eq 0 }
+  its('stdout') { should match(/2[0-9].[0-9]/) }
 end
 
 # NOTE: See https://github.com/sous-chefs/docker/pull/1194

--- a/test/integration/installation_package/inspec/assert_functioning_spec.rb
+++ b/test/integration/installation_package/inspec/assert_functioning_spec.rb
@@ -1,11 +1,4 @@
-if os.family == 'redhat' && os.release.to_i == 8
-  describe command('/usr/bin/docker --version') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/26\.1\./) }
-  end
-else
-  describe command('/usr/bin/docker --version') do
-    its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/27\.1\./) }
-  end
+describe command('/usr/bin/docker --version') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/2[0-9]\.[0-9]+\./) }
 end


### PR DESCRIPTION
This is needed if you're trying to use the system packages and not the upstream
repository. This is useful for non-standard CPU architectures which might not
have upstream support.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
