### PR TITLE
Fix issue with container network mode causing unnecessary redeployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix issue with container network mode causing unnecessary redeployment when using `container:<name>` format
+  - Added network mode normalization to handle container IDs consistently
+  - Prevents container recreation when only the container ID format changes
+
 ## 11.8.0 - *2024-12-11*
 
 - Add volume_prune resource

--- a/libraries/helpers_network.rb
+++ b/libraries/helpers_network.rb
@@ -31,7 +31,7 @@ module DockerCookbook
           container = Docker::Container.get(container_ref, {}, connection)
           # Return normalized form with full container ID
           "container:#{container.id}"
-        rescue Docker::Error::NotFoundError
+        rescue Docker::Error::NotFoundError, Docker::Error::TimeoutError
           # If container not found, return original value
           mode
         end

--- a/libraries/helpers_network.rb
+++ b/libraries/helpers_network.rb
@@ -20,6 +20,22 @@ module DockerCookbook
           container.info['NetworkSettings']['Networks'].values[0]['IPAMConfig']['IPv4Address']
         end
       end
+
+      def normalize_network_mode(mode)
+        return mode unless mode.is_a?(String) && mode.start_with?('container:')
+
+        # Extract container name/id from network mode
+        container_ref = mode.split(':', 2)[1]
+        begin
+          # Try to get the container by name or ID
+          container = Docker::Container.get(container_ref, {}, connection)
+          # Return normalized form with full container ID
+          "container:#{container.id}"
+        rescue Docker::Error::NotFoundError
+          # If container not found, return original value
+          mode
+        end
+      end
     end
   end
 end

--- a/libraries/helpers_network.rb
+++ b/libraries/helpers_network.rb
@@ -21,7 +21,7 @@ module DockerCookbook
         end
       end
 
-      def normalize_network_mode(mode)
+      def normalize_container_network_mode(mode)
         return mode unless mode.is_a?(String) && mode.start_with?('container:')
 
         # Extract container name/id from network mode

--- a/resources/container.rb
+++ b/resources/container.rb
@@ -405,7 +405,7 @@ load_current_value do |new_resource|
       value = (value / (10**9)).to_i
     when 'NetworkMode'
       property_name = 'network_mode'
-      value = normalize_network_mode(value)
+      value = normalize_container_network_mode(value)
     else
       property_name = to_snake_case(key)
     end
@@ -504,7 +504,7 @@ action :create do
           'MemorySwappiness' => new_resource.memory_swappiness,
           'MemoryReservation' => new_resource.memory_reservation,
           'NanoCpus'        => new_resource.cpus,
-          'NetworkMode'     => normalize_network_mode(new_resource.network_mode),
+          'NetworkMode'     => normalize_container_network_mode(new_resource.network_mode),
           'OomKillDisable'  => new_resource.oom_kill_disable,
           'OomScoreAdj'     => new_resource.oom_score_adj,
           'Privileged'      => new_resource.privileged,
@@ -747,10 +747,10 @@ action_class do
     new_resource.env_file.map { |f| ::File.readlines(f).map(&:strip) }.flatten
   end
 
-  def normalize_network_mode(value)
+  def normalize_container_network_mode(value)
     if value.is_a?(String) && value.start_with?('container:')
       # Use the network helper method for container network mode
-      DockerCookbook::DockerHelpers::Network.normalize_network_mode(value)
+      DockerCookbook::DockerHelpers::Network.normalize_container_network_mode(value)
     else
       case value
       when 'host'

--- a/resources/container.rb
+++ b/resources/container.rb
@@ -403,6 +403,9 @@ load_current_value do |new_resource|
     when 'NanoCpus'
       property_name = 'cpus'
       value = (value / (10**9)).to_i
+    when 'NetworkMode'
+      property_name = 'network_mode'
+      value = normalize_network_mode(value)
     else
       property_name = to_snake_case(key)
     end
@@ -501,7 +504,7 @@ action :create do
           'MemorySwappiness' => new_resource.memory_swappiness,
           'MemoryReservation' => new_resource.memory_reservation,
           'NanoCpus'        => new_resource.cpus,
-          'NetworkMode'     => new_resource.network_mode,
+          'NetworkMode'     => normalize_network_mode(new_resource.network_mode),
           'OomKillDisable'  => new_resource.oom_kill_disable,
           'OomScoreAdj'     => new_resource.oom_score_adj,
           'Privileged'      => new_resource.privileged,
@@ -742,5 +745,18 @@ action_class do
 
   def read_env_file
     new_resource.env_file.map { |f| ::File.readlines(f).map(&:strip) }.flatten
+  end
+
+  def normalize_network_mode(value)
+    case value
+    when 'host'
+      'host'
+    when 'none'
+      'none'
+    when 'default'
+      'bridge'
+    else
+      value
+    end
   end
 end

--- a/resources/container.rb
+++ b/resources/container.rb
@@ -748,15 +748,20 @@ action_class do
   end
 
   def normalize_network_mode(value)
-    case value
-    when 'host'
-      'host'
-    when 'none'
-      'none'
-    when 'default'
-      'bridge'
+    if value.is_a?(String) && value.start_with?('container:')
+      # Use the network helper method for container network mode
+      DockerCookbook::DockerHelpers::Network.normalize_network_mode(value)
     else
-      value
+      case value
+      when 'host'
+        'host'
+      when 'none'
+        'none'
+      when 'default'
+        'bridge'
+      else
+        value
+      end
     end
   end
 end


### PR DESCRIPTION
- Added network mode normalization to handle container IDs consistently
- Prevents container recreation when only the container ID format changes

Resolves #1273 