### PR TITLE
use rhel platform for all el8 and rhel 9+

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -67,6 +67,18 @@ platforms:
       image: dokken/oraclelinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: rhel-8
+    driver:
+      image: registry.access.redhat.com/ubi8/ubi-init
+      pid_one_command: /sbin/init
+
+  - name: rhel-9
+    driver:
+      image: registry.access.redhat.com/ubi9/ubi-init
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN dnf install -y libxcrypt-compat
+
   - name: rockylinux-8
     driver:
       image: dokken/rockylinux-8

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -17,6 +17,11 @@ def el7?
   false
 end
 
+def el8?
+  return true if platform_family?('rhel') && node['platform_version'].to_i == 8
+  false
+end
+
 def fedora?
   return true if platform?('fedora')
   false
@@ -124,7 +129,10 @@ action :create do
         if platform?('fedora')
           'fedora'
           # s390x is only available under rhel platform
-        elsif platform?('redhat') && arch == 's390x'
+        elsif platform?('redhat', 'oracle') && (arch == 's390x' || !el7?)
+          'rhel'
+          # use rhel for all el8 since CentOS 8 is dead
+        elsif el8? && !platform?('centos')
           'rhel'
         else
           'centos'

--- a/spec/docker_test/installation_package_spec.rb
+++ b/spec/docker_test/installation_package_spec.rb
@@ -69,7 +69,25 @@ describe 'docker_test::installation_package' do
     end
   end
 
-  context 'CentOS (s390x): testing default action, default properties' do
+  context 'CentOS 9: testing default action, default properties' do
+    platform 'centos-stream', '9'
+    cached(:subject) { chef_run }
+
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default')
+    end
+    it do
+      expect(chef_run).to create_yum_repository('Docker').with(
+        baseurl: 'https://download.docker.com/linux/centos/9/x86_64/stable',
+        gpgkey: 'https://download.docker.com/linux/centos/gpg',
+        description: 'Docker Stable repository',
+        gpgcheck: true,
+        enabled: true
+      )
+    end
+  end
+
+  context 'RHEL (s390x): testing default action, default properties' do
     platform 'redhat', '8'
     cached(:subject) { chef_run }
     automatic_attributes['kernel']['machine'] = 's390x'
@@ -80,6 +98,93 @@ describe 'docker_test::installation_package' do
     it do
       expect(chef_run).to create_yum_repository('Docker').with(
         baseurl: 'https://download.docker.com/linux/rhel/8/s390x/stable',
+        gpgkey: 'https://download.docker.com/linux/rhel/gpg',
+        description: 'Docker Stable repository',
+        gpgcheck: true,
+        enabled: true
+      )
+    end
+  end
+
+  context 'RHEL 8: testing default action, default properties' do
+    platform 'redhat', '8'
+    cached(:subject) { chef_run }
+
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default')
+    end
+    it do
+      expect(chef_run).to create_yum_repository('Docker').with(
+        baseurl: 'https://download.docker.com/linux/rhel/8/x86_64/stable',
+        gpgkey: 'https://download.docker.com/linux/rhel/gpg',
+        description: 'Docker Stable repository',
+        gpgcheck: true,
+        enabled: true
+      )
+    end
+  end
+
+  context 'RHEL 9: testing default action, default properties' do
+    platform 'redhat', '9'
+    cached(:subject) { chef_run }
+
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default')
+    end
+    it do
+      expect(chef_run).to create_yum_repository('Docker').with(
+        baseurl: 'https://download.docker.com/linux/rhel/9/x86_64/stable',
+        gpgkey: 'https://download.docker.com/linux/rhel/gpg',
+        description: 'Docker Stable repository',
+        gpgcheck: true,
+        enabled: true
+      )
+    end
+  end
+
+  context 'Oracle 7: testing default action, default properties' do
+    platform 'oracle', '7'
+    cached(:subject) { chef_run }
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default')
+    end
+    it do
+      expect(chef_run).to create_yum_repository('Docker').with(
+        baseurl: 'https://download.docker.com/linux/centos/7/x86_64/stable',
+        gpgkey: 'https://download.docker.com/linux/centos/gpg',
+        description: 'Docker Stable repository',
+        gpgcheck: true,
+        enabled: true
+      )
+    end
+  end
+
+  context 'Oracle 8: testing default action, default properties' do
+    platform 'oracle', '8'
+    cached(:subject) { chef_run }
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default')
+    end
+    it do
+      expect(chef_run).to create_yum_repository('Docker').with(
+        baseurl: 'https://download.docker.com/linux/rhel/8/x86_64/stable',
+        gpgkey: 'https://download.docker.com/linux/rhel/gpg',
+        description: 'Docker Stable repository',
+        gpgcheck: true,
+        enabled: true
+      )
+    end
+  end
+
+  context 'Oracle 9: testing default action, default properties' do
+    platform 'oracle', '9'
+    cached(:subject) { chef_run }
+    it 'installs docker' do
+      expect(chef_run).to create_docker_installation_package('default')
+    end
+    it do
+      expect(chef_run).to create_yum_repository('Docker').with(
+        baseurl: 'https://download.docker.com/linux/rhel/9/x86_64/stable',
         gpgkey: 'https://download.docker.com/linux/rhel/gpg',
         description: 'Docker Stable repository',
         gpgcheck: true,


### PR DESCRIPTION
# Description

makes it so newer RHEL and Oracle can use the `rhel` platform yum repos.

I added Red Hat UBI 8 and 9 platforms to the `kitchen.dokken.yml` but I don't know if you want those or not.

## Issues Resolved

fixes #1276

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
