### PR TITLE
fix: avoid Docker restart on apt refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ end
 - `package_options` - Manually specify additional options, like apt-get directives for example
 - `setup_docker_repo` - Setup the download.docker.com repo. If you would like to manage the repo yourself so you can use an internal repo then set this to false. default: true on all platforms except Amazon Linux.
 - `repo_channel` - The channel of docker to setup from download.docker.com. Only used if `setup_docker_repo` is true. default: 'stable'
-- `restart_service` - Internal property set automatically by `docker_service` to restart Docker after a package change. Do not set this in a recipe.
+- `restart_target` - Internal service-resource reference set automatically by `docker_service`. The package resource notifies this target only when the Docker package changes. Do not set this in a recipe.
 
 ## docker_service_manager
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ end
 - `package_options` - Manually specify additional options, like apt-get directives for example
 - `setup_docker_repo` - Setup the download.docker.com repo. If you would like to manage the repo yourself so you can use an internal repo then set this to false. default: true on all platforms except Amazon Linux.
 - `repo_channel` - The channel of docker to setup from download.docker.com. Only used if `setup_docker_repo` is true. default: 'stable'
+- `restart_service` - Internal `Chef::Resource` notification target used by `docker_service` so only Docker package changes trigger an immediate service restart. Most users should not set this directly.
 
 ## docker_service_manager
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ end
 - `package_options` - Manually specify additional options, like apt-get directives for example
 - `setup_docker_repo` - Setup the download.docker.com repo. If you would like to manage the repo yourself so you can use an internal repo then set this to false. default: true on all platforms except Amazon Linux.
 - `repo_channel` - The channel of docker to setup from download.docker.com. Only used if `setup_docker_repo` is true. default: 'stable'
-- `restart_service` - Internal `Chef::Resource` notification target used by `docker_service` so only Docker package changes trigger an immediate service restart. Most users should not set this directly.
+- `restart_service` - Internal property set automatically by `docker_service` to restart Docker after a package change. Do not set this in a recipe.
 
 ## docker_service_manager
 

--- a/documentation/docker_installation_package.md
+++ b/documentation/docker_installation_package.md
@@ -33,9 +33,8 @@ end
 ```
 
 The `docker_service` resource creates the package-installation resource and
-passes itself as that resource's `restart_target`. In plain English, it tells
-the package installer: "If you change the Docker package, notify this Docker
-service resource."
+passes itself as that resource's `restart_target`. This tells the package
+installer which Docker service resource to notify after changing the package.
 
 The relevant internal code is equivalent to:
 

--- a/documentation/docker_installation_package.md
+++ b/documentation/docker_installation_package.md
@@ -75,48 +75,6 @@ it does not manage or restart the Docker service.
 `restart_target` implements the handoff between these two resources. It is set
 automatically by `docker_service` and should not be set in a recipe.
 
-### Applying This Pattern Elsewhere
-
-This pattern is useful when a higher-level resource coordinates separate
-install, configuration, and service resources:
-
-```ruby
-service_target = new_resource
-
-application_install 'example' do
-  restart_target service_target
-end
-
-application_config 'example' do
-  reload_target service_target
-end
-```
-
-The lower-level resources place notifications on the changes that require them:
-
-```ruby
-package 'example' do
-  notifies :restart, restart_target, :immediately
-end
-
-template '/etc/example.conf' do
-  notifies :reload, reload_target, :delayed
-end
-```
-
-This keeps the responsibilities separate:
-
-- The install resource knows which package changes require a restart.
-- The configuration resource knows which file changes require a reload or
-  restart.
-- The service resource owns the `:start`, `:stop`, `:reload`, and `:restart`
-  actions.
-- The higher-level resource connects them by passing the service resource as the
-  notification target.
-
-These generic examples illustrate the reusable pattern. The Docker cookbook
-currently uses it only for package-triggered restarts.
-
 ## Examples
 
 ### Install Latest Version of Docker

--- a/documentation/docker_installation_package.md
+++ b/documentation/docker_installation_package.md
@@ -18,9 +18,9 @@ The `docker_installation_package` resource is responsible for installing Docker 
 | `version`           | String           | `nil`                   | Docker version to install (e.g., '20.10.23')            |
 | `package_options`   | String           | `nil`                   | Additional options to pass to the package manager       |
 | `site_url`          | String           | `'download.docker.com'` | Docker repository URL                                   |
-| `restart_service`   | `Chef::Resource` | `nil`                   | Internal property set automatically by `docker_service` |
+| `restart_target`    | `Chef::Resource` | `nil`                   | Internal property set automatically by `docker_service` |
 
-### Restart Behavior
+### How Package-Triggered Restarts Work
 
 Use `docker_service` when this cookbook should install Docker and manage its
 service:
@@ -32,17 +32,91 @@ docker_service 'default' do
 end
 ```
 
-With this usage:
+The `docker_service` resource creates the package-installation resource and
+passes itself as that resource's `restart_target`. In plain English, it tells
+the package installer: "If you change the Docker package, notify this Docker
+service resource."
+
+The relevant internal code is equivalent to:
+
+```ruby
+service_to_restart = new_resource
+
+docker_installation_package 'default' do
+  restart_target service_to_restart
+end
+```
+
+Passing the object does **not** restart Docker. It only identifies which Chef
+resource should receive a future notification. The package resource decides
+whether to send that notification. Think of `restart_target` as an address:
+passing the address does not send a message; it tells Chef where to deliver the
+message if the package changes.
+
+The package resource uses that address here:
+
+```ruby
+package 'docker-ce' do
+  notifies :restart, restart_target, :immediately
+end
+```
+
+Chef sends a resource's notifications only when that resource updates the
+system. The results are therefore:
 
 - A Docker package install or upgrade restarts Docker immediately.
+- A Chef run where the Docker package is already correct does not restart
+  Docker.
 - A repository or package-cache update without a package change does not restart
   Docker.
 
 If you call `docker_installation_package` directly, it only manages the package;
 it does not manage or restart the Docker service.
 
-`restart_service` implements the handoff between these two resources. It is set
+`restart_target` implements the handoff between these two resources. It is set
 automatically by `docker_service` and should not be set in a recipe.
+
+### Applying This Pattern Elsewhere
+
+This pattern is useful when a higher-level resource coordinates separate
+install, configuration, and service resources:
+
+```ruby
+service_target = new_resource
+
+application_install 'example' do
+  restart_target service_target
+end
+
+application_config 'example' do
+  reload_target service_target
+end
+```
+
+The lower-level resources place notifications on the changes that require them:
+
+```ruby
+package 'example' do
+  notifies :restart, restart_target, :immediately
+end
+
+template '/etc/example.conf' do
+  notifies :reload, reload_target, :delayed
+end
+```
+
+This keeps the responsibilities separate:
+
+- The install resource knows which package changes require a restart.
+- The configuration resource knows which file changes require a reload or
+  restart.
+- The service resource owns the `:start`, `:stop`, `:reload`, and `:restart`
+  actions.
+- The higher-level resource connects them by passing the service resource as the
+  notification target.
+
+These generic examples illustrate the reusable pattern. The Docker cookbook
+currently uses it only for package-triggered restarts.
 
 ## Examples
 

--- a/documentation/docker_installation_package.md
+++ b/documentation/docker_installation_package.md
@@ -9,15 +9,34 @@ The `docker_installation_package` resource is responsible for installing Docker 
 
 ## Properties
 
-| Property            | Type    | Default                 | Description                                             |
-|---------------------|---------|-------------------------|---------------------------------------------------------|
-| `setup_docker_repo` | Boolean | `true`                  | Whether to set up the Docker repository                 |
-| `repo_channel`      | String  | `'stable'`              | Repository channel to use (`stable`, `test`, `nightly`) |
-| `package_name`      | String  | `'docker-ce'`           | Name of the Docker package to install                   |
-| `package_version`   | String  | `nil`                   | Specific package version to install                     |
-| `version`           | String  | `nil`                   | Docker version to install (e.g., '20.10.23')            |
-| `package_options`   | String  | `nil`                   | Additional options to pass to the package manager       |
-| `site_url`          | String  | `'download.docker.com'` | Docker repository URL                                   |
+| Property            | Type             | Default                 | Description                                             |
+|---------------------|------------------|-------------------------|---------------------------------------------------------|
+| `setup_docker_repo` | Boolean          | `true`                  | Whether to set up the Docker repository                 |
+| `repo_channel`      | String           | `'stable'`              | Repository channel to use (`stable`, `test`, `nightly`) |
+| `package_name`      | String           | `'docker-ce'`           | Name of the Docker package to install                   |
+| `package_version`   | String           | `nil`                   | Specific package version to install                     |
+| `version`           | String           | `nil`                   | Docker version to install (e.g., '20.10.23')            |
+| `package_options`   | String           | `nil`                   | Additional options to pass to the package manager       |
+| `site_url`          | String           | `'download.docker.com'` | Docker repository URL                                   |
+| `restart_service`   | `Chef::Resource` | `nil`                   | Internal service notification target                    |
+
+### Internal Service Notification
+
+`restart_service` is internal wiring used by the `docker_service` resource.
+Normal cookbook consumers should not set it directly. `docker_service` passes
+its own resource object to `docker_installation_package`, which uses Chef's
+direct-resource notification support to restart Docker immediately when the
+Docker package changes. Repository metadata updates do not trigger the restart.
+
+The internal call has this shape:
+
+```ruby
+service = new_resource
+
+docker_installation_package 'default' do
+  restart_service service
+end
+```
 
 ## Examples
 

--- a/documentation/docker_installation_package.md
+++ b/documentation/docker_installation_package.md
@@ -18,25 +18,31 @@ The `docker_installation_package` resource is responsible for installing Docker 
 | `version`           | String           | `nil`                   | Docker version to install (e.g., '20.10.23')            |
 | `package_options`   | String           | `nil`                   | Additional options to pass to the package manager       |
 | `site_url`          | String           | `'download.docker.com'` | Docker repository URL                                   |
-| `restart_service`   | `Chef::Resource` | `nil`                   | Internal service notification target                    |
+| `restart_service`   | `Chef::Resource` | `nil`                   | Internal property set automatically by `docker_service` |
 
-### Internal Service Notification
+### Restart Behavior
 
-`restart_service` is internal wiring used by the `docker_service` resource.
-Normal cookbook consumers should not set it directly. `docker_service` passes
-its own resource object to `docker_installation_package`, which uses Chef's
-direct-resource notification support to restart Docker immediately when the
-Docker package changes. Repository metadata updates do not trigger the restart.
-
-The internal call has this shape:
+Use `docker_service` when this cookbook should install Docker and manage its
+service:
 
 ```ruby
-service = new_resource
-
-docker_installation_package 'default' do
-  restart_service service
+docker_service 'default' do
+  install_method 'package'
+  action [:create, :start]
 end
 ```
+
+With this usage:
+
+- A Docker package install or upgrade restarts Docker immediately.
+- A repository or package-cache update without a package change does not restart
+  Docker.
+
+If you call `docker_installation_package` directly, it only manages the package;
+it does not manage or restart the Docker service.
+
+`restart_service` implements the handoff between these two resources. It is set
+automatically by `docker_service` and should not be set in a recipe.
 
 ## Examples
 

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -20,7 +20,7 @@ property :version, String, desired_state: false
 property :package_options, String, desired_state: false
 property :site_url, String, default: 'download.docker.com'
 property :restart_service, Chef::Resource,
-         description: 'Internal notification target used by docker_service to restart Docker only when the package changes',
+         description: 'Internal: the docker_service resource to notify when the Docker package changes',
          desired_state: false
 
 def el7?

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -19,7 +19,9 @@ property :package_version, String, desired_state: false
 property :version, String, desired_state: false
 property :package_options, String, desired_state: false
 property :site_url, String, default: 'download.docker.com'
-property :restart_service, Chef::Resource, desired_state: false
+property :restart_service, Chef::Resource,
+         description: 'Internal notification target used by docker_service to restart Docker only when the package changes',
+         desired_state: false
 
 def el7?
   return true if platform_family?('rhel') && node['platform_version'].to_i == 7

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -19,6 +19,7 @@ property :package_version, String, desired_state: false
 property :version, String, desired_state: false
 property :package_options, String, desired_state: false
 property :site_url, String, default: 'download.docker.com'
+property :restart_service, Chef::Resource, desired_state: false
 
 def el7?
   return true if platform_family?('rhel') && node['platform_version'].to_i == 7
@@ -173,11 +174,13 @@ action :create do
   end
 
   version = new_resource.package_version || version_string(new_resource.version)
+  restart_service = new_resource.restart_service
 
   package new_resource.package_name do
     version version
     options new_resource.package_options
     action :install
+    notifies :restart, restart_service, :immediately if restart_service
   end
 end
 

--- a/resources/installation_package.rb
+++ b/resources/installation_package.rb
@@ -19,7 +19,7 @@ property :package_version, String, desired_state: false
 property :version, String, desired_state: false
 property :package_options, String, desired_state: false
 property :site_url, String, default: 'download.docker.com'
-property :restart_service, Chef::Resource,
+property :restart_target, Chef::Resource,
          description: 'Internal: the docker_service resource to notify when the Docker package changes',
          desired_state: false
 
@@ -176,13 +176,13 @@ action :create do
   end
 
   version = new_resource.package_version || version_string(new_resource.version)
-  restart_service = new_resource.restart_service
+  restart_target = new_resource.restart_target
 
   package new_resource.package_name do
     version version
     options new_resource.package_options
     action :install
-    notifies :restart, restart_service, :immediately if restart_service
+    notifies :restart, restart_target, :immediately if restart_target
   end
 end
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -95,9 +95,14 @@ end
 action :create do
   validate_install_method
 
+  service = new_resource
   installation do
     action :create
-    notifies :restart, new_resource, :immediately
+    if service.install_method == 'package'
+      restart_service service
+    else
+      notifies :restart, service, :immediately
+    end
   end
 end
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -99,7 +99,7 @@ action :create do
   installation do
     action :create
     if service.install_method == 'package'
-      restart_service service
+      restart_target service
     else
       notifies :restart, service, :immediately
     end

--- a/spec/test/package_restart_spec.rb
+++ b/spec/test/package_restart_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'test::package_restart' do
+  platform 'ubuntu', '24.04'
+  step_into :docker_service, :docker_installation_package
+
+  it 'restarts the service when the Docker package changes' do
+    expect(chef_run.package('docker-ce')).to notify('docker_service[default]').to(:restart).immediately
+  end
+end

--- a/test/cookbooks/test/recipes/package_restart.rb
+++ b/test/cookbooks/test/recipes/package_restart.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+docker_service 'default' do
+  install_method 'package'
+  service_manager 'none'
+  setup_docker_repo false
+  action :create
+end


### PR DESCRIPTION
## Summary

- attach Docker restart notifications to the actual package resource instead of the aggregate installation resource
- prevent periodic APT cache refreshes from restarting an unchanged Docker service
- preserve immediate restarts when the Docker package genuinely changes
- retain existing script and tarball installation behavior

Closes #1336.

## Verification

- `chef install Policyfile.rb`
- `cookstyle --no-server` (96 files, no offenses)
- ChefSpec (275 examples, 0 failures)
- `kitchen test default-ubuntu-2404` (5 assertions, 0 failures)
- forced APT-cache refresh converge: Docker package remained current and the service start timestamp was unchanged
- independent spec and code-quality review: passed
